### PR TITLE
Add a getter to return Config without pointer

### DIFF
--- a/inc/ABlock.class.hpp
+++ b/inc/ABlock.class.hpp
@@ -26,7 +26,6 @@ class ABlock
 
 
 public:
-	static const std::string blockStartKeyword;
 	ABlock(ConfigFile &confFile);
 
 	virtual void handle();

--- a/inc/ConfigFile.class.hpp
+++ b/inc/ConfigFile.class.hpp
@@ -21,19 +21,23 @@
 class ConfigFile
 {
 public:
+	ConfigFile();
 	ConfigFile(std::string filename);
+
+	void openFile(std::string filename);
+
 	// void next();
 	int getNext();
 	std::string getLineString(void) const;
 
 private:
-	int fd;
-	int ret;
-	char *line;
+	int _fd;
+	int _ret;
+	char *_line;
 
-	bool lastLineRead;
-	bool lastLineSent;
-	std::string lineString;
+	bool _lastLineRead;
+	bool _lastLineSent;
+	std::string _lineString;
 };
 
 # endif

--- a/inc/ConfigReader.class.hpp
+++ b/inc/ConfigReader.class.hpp
@@ -39,6 +39,7 @@ public:
 	ConfigReader(std::string filename);
 
 	Config *createConfig();
+	Config getConfig(void) const;
 
 private:
 	// int fd;
@@ -48,6 +49,7 @@ private:
 	ConfigFile confFile;
 
 	Config *configBlock;
+	Config _config;
 	std::string lineString;
 
 	// virtualHostPrototype vhp;

--- a/src/config/Config.class.cpp
+++ b/src/config/Config.class.cpp
@@ -102,42 +102,6 @@ void Config::handleLine(std::string lineString)
 	{
 		this->root = getStringDirective(lineString, "root");
 	}
-
-	// if (isPresent(lineString, "root"))
-	// {
-	// 	this->root = getStringDirective(lineString, "root");
-	// 	this->rootSet = true;
-	// }
-	// if (isPresent(lineString, "location"))
-	// {
-	// 	this->pattern = parsePattern(lineString);
-	// }
-	// if (isPresent(lineString, "client_max_body_size"))
-	// {
-	// 	this->clientMaxBodySize = parseClientMaxBodySize(lineString);
-	// }
-	// if (isPresent(lineString, "autoindex"))
-	// {
-	// 	this->autoindex = parseBoolDirective(getStringDirective(lineString, "autoindex"));
-	// }
-	// if (isPresent(lineString, "fastcgi_pass"))
-	// {
-	// 	this->fcgiPass = getStringDirective(lineString, "fastcgi_pass");
-	// 	this->fcgiSet = true;
-	// }
-	// if (isPresent(lineString, "fastcgi_param"))
-	// {
-	// 	parseFastCGIParam(lineString, this->fcgiParams);
-	// }
-	// else if (isPresent(lineString, "index"))
-	// {
-	// 	this->index = ft_split(getStringDirective(lineString, "index"), ' ');
-	// }
-	// else if (isPresent(lineString, "upload_store"))
-	// {
-	// 	this->uploadStore = getStringDirective(lineString, "upload_store");
-	// 	this->uploadStoreSet = true;
-	// }
 }
 
 std::vector<VirtualHost> Config::getVirtualHostVector(void) const

--- a/src/config/ConfigFile.class.cpp
+++ b/src/config/ConfigFile.class.cpp
@@ -12,11 +12,22 @@
 
 # include "ConfigFile.class.hpp"
 
-ConfigFile::ConfigFile(std::string filename) :
-	lastLineRead(false), lastLineSent(false)
+ConfigFile::ConfigFile() : _fd(-1)
 {
-	this->fd = open(filename.c_str(), O_RDONLY);
-	if (fd < 0)
+}
+
+void ConfigFile::openFile(std::string filename)
+{
+	this->_fd = open(filename.c_str(), O_RDONLY);
+	if (_fd < 0)
+		throw Exception("Couldn't open file");
+}
+
+ConfigFile::ConfigFile(std::string filename) :
+	_lastLineRead(false), _lastLineSent(false)
+{
+	this->_fd = open(filename.c_str(), O_RDONLY);
+	if (_fd < 0)
 		throw Exception("Couldn't open file");
 
 	// while ((ret = fd_get_next_line(fd, &line)))
@@ -37,25 +48,31 @@ ConfigFile::ConfigFile(std::string filename) :
 
 int ConfigFile::getNext()
 {
-	if (lastLineSent)
+	if (this->_fd < 0)
+		throw Exception("File not open");
+
+	if (_lastLineSent)
 		return 0;
 
-	if (lastLineRead)
+	if (_lastLineRead)
 	{
-		lastLineSent = true;
+		_lastLineSent = true;
 		return 0;
 	}
-	this->ret = fd_get_next_line(this->fd, &(this->line));
-	this->lineString.assign(this->line);
-	if (ret == 0)
+	this->_ret = fd_get_next_line(this->_fd, &(this->_line));
+	this->_lineString.assign(this->_line);
+	if (_ret == 0)
 	{
-		lastLineRead = true;
+		_lastLineRead = true;
 		return 1;
 	}
-	return this->ret;
+	return this->_ret;
 }
 
 std::string ConfigFile::getLineString(void) const
 {
-	return this->lineString;
+	if (this->_fd < 0)
+		throw Exception("File not open");
+
+	return this->_lineString;
 }

--- a/src/config/ConfigReader.class.cpp
+++ b/src/config/ConfigReader.class.cpp
@@ -27,9 +27,9 @@ void ConfigReader::parse()
 	// std::cout << "Parse: " << lineString << std::endl;
 
 
-	configBlock = new Config(confFile);
-
-	configBlock->handle();
+	// configBlock = new Config(confFile);
+	// _config = Config(confFile)
+	// configBlock->handle();
 	// if (lineString.find("server") != std::string::npos)
 	// {
 	// 	ServerBlock sb(this->confFile);
@@ -38,34 +38,14 @@ void ConfigReader::parse()
 	// 	serverBlockVector.push_back(sb);
 	// 	// ABlock(this->confFile);
 
-	// }
-	// size_t needle;
-	// if (lineString.find("server") != std::string::npos)
-	// {
-	// 	this->parse_server();
-	// }
-	// else if ((needle = lineString.find(
-	// 			"client_max_body_size")) != std::string::npos)
-	// {
-	// 	cp.clientMaxBodySize = parse_size(needle+20, lineString);
-	// }
-	// else if ((needle = lineString.find("autoindex")) != std::string::npos)
-	// {
-	// 	cp.autoindex = parseBoolDirective(getDirective(needle+9, lineString));
-	// }
-	// else if ((needle = lineString.find("index")) != std::string::npos)
-	// {
-	// 	cp.index = split(getDirective(
-	// 		needle+5, lineString), ' ');
-	// }
-	// else if ((needle = lineString.find("root")) != std::string::npos)
-	// {
-	// 	cp.root = getDirective(needle+4, lineString);
-	// }
+	_config.handle();
+	configBlock = &_config;
+
+
 }
 
 ConfigReader::ConfigReader(std::string filename) :
-	confFile(filename)
+	confFile(filename), _config(confFile)
 {
 	// lastLineParsed = "";
 	// fd = open(filename.c_str(), O_RDONLY);
@@ -91,4 +71,9 @@ ConfigReader::ConfigReader(std::string filename) :
 Config *ConfigReader::createConfig()
 {
 	return configBlock;
+}
+
+Config ConfigReader::getConfig(void) const
+{
+	return this->_config;
 }

--- a/tests/config/unit_tests.cpp
+++ b/tests/config/unit_tests.cpp
@@ -6,7 +6,7 @@
 /*   By: ashishae <ashishae@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/12/17 17:45:02 by ashishae          #+#    #+#             */
-/*   Updated: 2021/02/16 16:19:49 by ashishae         ###   ########.fr       */
+/*   Updated: 2021/02/17 16:01:26 by ashishae         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -74,18 +74,27 @@ int main(void)
 	out("Simple config");
 	ConfigReader r("./config/test_configs/nginx.conf");
 
-	Config *conf = r.createConfig();
+	// Config *conf = r.createConfig();
+	Config conf = r.getConfig();
 
-	check(conf->getAutoindex() == true);
-	check(conf->getClientMaxBodySize() == 32);
-	check(conf->getIndex().size() == 1);
-	check(conf->getIndex()[0] == "index.html");
+	check(conf.getAutoindex() == true);
+	check(conf.getClientMaxBodySize() == 32);
+	check(conf.getIndex().size() == 1);
+	check(conf.getIndex()[0] == "index.html");
 
-	std::vector<VirtualHost> virtualHostVector = conf->getVirtualHostVector();
+	Config *_conf = r.createConfig();
+
+	check(_conf->getAutoindex() == true);
+	check(_conf->getClientMaxBodySize() == 32);
+	check(_conf->getIndex().size() == 1);
+	check(_conf->getIndex()[0] == "index.html");
+
+
+	std::vector<VirtualHost> virtualHostVector = conf.getVirtualHostVector();
 	check(virtualHostVector.size() == 3);
 
 	out("Config | Root");
-	check(conf->getRoot() == "/var/www/");
+	check(conf.getRoot() == "/var/www/");
 
 	out("Host 0 | Listen");
 	check(virtualHostVector[0].getListenIp() == 80);


### PR DESCRIPTION
This pull request adds a new getter to ConfigReader that returns its Config object directly. Before, ConfigReader returned a pointer to a new-allocated Config, which required to be deleted.

```Config getConfig(void) const;```

I left the old getter for compatibility and will remove it later.