### PR TITLE
Allow multiple methods in LimitExcept

### DIFF
--- a/inc/ABlock.class.hpp
+++ b/inc/ABlock.class.hpp
@@ -28,9 +28,15 @@ class ABlock
 public:
 	ABlock(ConfigFile &confFile);
 
+	// ABlock(ABlock &ab);
+
+	// ABlock(ABlock *ab);
+
 	virtual void handle();
 
 	static bool blockStarted(std::string lineString);
+
+	void handleLineCommon(std::string lineString);
 
 	virtual void handleLine(std::string lineString);
 
@@ -56,8 +62,20 @@ public:
 	static void checkLine(std::string lineString);
 	virtual ~ABlock();
 
+	int getClientMaxBodySize(void) const;
+	bool getAutoindex(void) const;
+	std::vector<std::string> getIndex(void) const;
+	std::string getRoot(void) const;
+
 private:
 	ConfigFile &_confFile;
+
+	int _clientMaxBodySize;
+	bool _autoindex;
+	std::vector<std::string> _index;
+	std::string _root;
+
+
 
 };
 

--- a/inc/Config.class.hpp
+++ b/inc/Config.class.hpp
@@ -24,19 +24,19 @@ public:
 	void handle();
 
 	std::vector<VirtualHost> getVirtualHostVector(void) const;
-	int getClientMaxBodySize(void) const;
-	bool getAutoindex(void) const;
-	std::vector<std::string> getIndex(void) const;
-	std::string getRoot(void) const;
+	// int getClientMaxBodySize(void) const;
+	// bool getAutoindex(void) const;
+	// std::vector<std::string> getIndex(void) const;
+	// std::string getRoot(void) const;
 
 	void check(void);
 
 private:
 	std::vector<VirtualHost> virtualHostVector;
-	int clientMaxBodySize;
-	bool autoindex;
-	std::vector<std::string> index;
-	std::string root;
+	// int clientMaxBodySize;
+	// bool autoindex;
+	// std::vector<std::string> index;
+	// std::string root;
 
 };
 

--- a/inc/LimitExcept.class.hpp
+++ b/inc/LimitExcept.class.hpp
@@ -29,11 +29,15 @@ public:
 	std::vector<std::string> getDeny(void) const;
 	std::vector<std::string> getMethods(void) const;
 
+	bool isEmpty(void) const;
+
 
 private:
 	std::vector<std::string> _allow;
 	std::vector<std::string> _deny;
 	std::vector<std::string> _methods;
+
+	bool _empty;
 
 };
 

--- a/inc/LimitExcept.class.hpp
+++ b/inc/LimitExcept.class.hpp
@@ -23,17 +23,17 @@ public:
 	LimitExcept(ConfigFile &confFile);
 	virtual void handleLine(std::string lineString);
 
-	static std::string parseMethod(std::string line);
+	static std::vector<std::string> parseMethods(std::string line);
 	
 	std::vector<std::string> getAllow(void) const;
 	std::vector<std::string> getDeny(void) const;
-	std::string getMethod(void) const;
+	std::vector<std::string> getMethods(void) const;
 
 
 private:
-	std::vector<std::string> allow;
-	std::vector<std::string> deny;
-	std::string method;
+	std::vector<std::string> _allow;
+	std::vector<std::string> _deny;
+	std::vector<std::string> _methods;
 
 };
 

--- a/inc/Location.class.hpp
+++ b/inc/Location.class.hpp
@@ -21,23 +21,24 @@
 # include "Utility.hpp"
 # include "LimitExcept.class.hpp"
 
-
 class Location : public ABlock
 {
 public:
 	Location(ConfigFile &confFile);
+
+	Location(ABlock &ab);
 	void handleLine(std::string lineString);
 
-	void inheritParams(int clientMaxBodySize, bool autoindex, std::string root,
-			std::vector<std::string> index, std::string uploadStore);
+	// void inheritParams(int clientMaxBodySize, bool autoindex, std::string root,
+	// 		std::vector<std::string> index, std::string uploadStore);
 
-	void inheritParams(ABlock *parent);
+	// void inheritParams(ABlock *parent);
 
 	std::string getPattern(void) const;
-	std::string getRoot(void) const;
-	int getClientMaxBodySize(void) const;
-	bool getAutoindex(void) const;
-	std::vector<std::string> getIndex(void) const;
+	// std::string getRoot(void) const;
+	// int getClientMaxBodySize(void) const;
+	// bool getAutoindex(void) const;
+	// std::vector<std::string> getIndex(void) const;
 	// LimitExcept getLimitExcept(void) const;
 
 
@@ -50,17 +51,17 @@ public:
 	bool getRootSet(void) const;
 	bool getUploadStoreSet(void) const;
 
+	void setUploadStore(std::string uploadStore);
+
 	void check(void);
 
 private:
 
 	static std::string parsePattern(std::string line);
 
-	int clientMaxBodySize;
-	bool autoindex;
 	std::string pattern;
-	std::string root;
-	std::vector<std::string> index;
+	
+	// std::vector<std::string> index;
 	// LimitExcept limitExcept;
 
 	LimitExcept limitExcept;

--- a/inc/VirtualHost.class.hpp
+++ b/inc/VirtualHost.class.hpp
@@ -20,20 +20,22 @@ class VirtualHost : public ABlock
 {
 public:
 	VirtualHost(ConfigFile &confFile);
+
+	VirtualHost(ABlock &ab);
 	void handleLine(std::string lineString);
 
 	int getListenIp(void) const;
 	std::string getListenHost(void) const;
 	std::vector<std::string> getServerName(void) const;
 	std::vector<Location> getLocations(void) const;
-	int getClientMaxBodySize(void) const;
-	bool getAutoindex(void) const;
-	std::vector<std::string> getIndex(void) const;
+	// int getClientMaxBodySize(void) const;
+	// bool getAutoindex(void) const;
+	// std::vector<std::string> getIndex(void) const;
 	std::string getUploadStore(void) const;
-	std::string getRoot(void) const;
+	// std::string getRoot(void) const;
 
-	void inheritParams(int clientMaxBodySize, bool autoindex, std::string root,
-			std::vector<std::string> index);
+	// void inheritParams(int clientMaxBodySize, bool autoindex, std::string root,
+			// std::vector<std::string> index);
 
 	void check(void);
 
@@ -41,14 +43,11 @@ private:
 	std::vector<Location> locationBlockVector;
 
 	int listenIp;
-	int clientMaxBodySize;
-	bool autoindex;
 	std::string listenHost;
 	std::vector<std::string> serverName;
 	std::vector<Location> locations;
-	std::vector<std::string> index;
 	std::string uploadStore;
-	std::string root;
+	// std::string root;
 
 };
 

--- a/inc/VirtualHost.class.hpp
+++ b/inc/VirtualHost.class.hpp
@@ -35,6 +35,8 @@ public:
 	void inheritParams(int clientMaxBodySize, bool autoindex, std::string root,
 			std::vector<std::string> index);
 
+	void check(void);
+
 private:
 	std::vector<Location> locationBlockVector;
 

--- a/inc/femtotest.hpp
+++ b/inc/femtotest.hpp
@@ -6,7 +6,7 @@
 /*   By: ashishae <ashishae@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/31 12:17:05 by ashishae          #+#    #+#             */
-/*   Updated: 2021/01/31 12:19:04 by ashishae         ###   ########.fr       */
+/*   Updated: 2021/02/19 11:43:49 by ashishae         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,6 +22,9 @@
 # include <iostream>
 
 bool exception_thrown = false;
+
+int total_checks = 0;
+int tests_passed = 0;
 
 void check(int expression);
 
@@ -53,15 +56,23 @@ void check(int expression)
 {
 	// If expression doesn't evaluate to 1, the program will abort
 	// assert(expression == 1);
+	total_checks += 1;
 	if (expression == 1)
 	{
 		std::cout << "\033[92m✓ PASS\033[0m" << std::endl;
+		tests_passed += 1;
 	}
 	else 
 	{
 		std::cout << "\033[91m✓ FAIL\033[0m" << std::endl;
 	}
 	
+}
+
+void test_results()
+{
+	std::cout << "\n\n---------" << std::endl;
+	std::cout << "Total checks: " << total_checks << ", passed: " << tests_passed << ", failed: " << total_checks - tests_passed << std::endl;
 }
 
 template <typename T>

--- a/src/Utility.cpp
+++ b/src/Utility.cpp
@@ -59,3 +59,25 @@ std::string		replacehtml(std::string src, std::string var, std::string value)
 	}
 	return (src);
 }
+
+/*
+** Split a string s, separated by delimiter c
+** @param s String that needs to be splitted
+** @param c The delimiter
+** @ret std::vector<std::string> the vector of resulting separated strings
+*/
+std::vector<std::string> ft_split(std::string s, char c)
+{
+	std::vector<std::string> ret;
+	if (s.size() == 0)
+		return ret;
+	int i = 0;
+	size_t pos;
+	while ((pos = s.find(c, i)) != std::string::npos)
+	{
+		ret.push_back(s.substr(i, pos-i));
+		i = pos+1;
+	}
+	ret.push_back(s.substr(i));
+	return ret;
+}

--- a/src/config/ABlock.class.cpp
+++ b/src/config/ABlock.class.cpp
@@ -71,7 +71,7 @@ void ABlock::handle()
 	while(_confFile.getNext());
 	if (!blockClosed)
 		throw Exception("A block wasn't closed");
-	check();
+	// check();
 }
 
 void ABlock::handleLine(std::string lineString)
@@ -166,26 +166,6 @@ int	ft_atoi(const char *str)
 		str++;
 	}
 	return (nbr * sign);
-}
-
-/*
-** Split a string s, separated by delimiter c
-** @param s String that needs to be splitted
-** @param c The delimiter
-** @ret std::vector<std::string> the vector of resulting separated strings
-*/
-std::vector<std::string> ft_split(std::string s, char c)
-{
-	std::vector<std::string> ret;
-	int i = 0;
-	size_t pos;
-	while ((pos = s.find(c, i)) != std::string::npos)
-	{
-		ret.push_back(s.substr(i, pos-i));
-		i = pos+1;
-	}
-	ret.push_back(s.substr(i));
-	return ret;
 }
 
 

--- a/src/config/ABlock.class.cpp
+++ b/src/config/ABlock.class.cpp
@@ -25,9 +25,29 @@
 // }
 
 ABlock::ABlock(ConfigFile &confFile) :
-	_confFile(confFile)
+	_confFile(confFile),
+	_clientMaxBodySize(0),
+	_autoindex(false),
+	_index(std::vector<std::string>())
 {
 }
+
+// ABlock::ABlock(ABlock &ab) :
+// 	_confFile(ab._confFile),
+// 	_clientMaxBodySize(ab._clientMaxBodySize),
+// 	_autoindex(ab._autoindex),
+// 	_index(ab._index)
+// {
+// }
+
+// ABlock::ABlock(ABlock *ab) :
+// 	_confFile(ab->_confFile),
+// 	_clientMaxBodySize(ab->_clientMaxBodySize),
+// 	_autoindex(ab->_autoindex),
+// 	_index(ab->_index)
+// {
+// }
+
 
 int ABlock::countOccurence(std::string s, char c)
 {
@@ -57,21 +77,42 @@ void ABlock::handle()
 	bool blockClosed = false;
 	do
 	{
-		checkLine(_confFile.getLineString());
+		std::string ls = _confFile.getLineString();
+		checkLine(ls);
 
-		if (_confFile.getLineString().find("}") != std::string::npos)
+		if (ls.find("}") != std::string::npos)
 		{
 			blockClosed = true;
 			break;
 		}
 
-		handleLine(_confFile.getLineString());
+		handleLineCommon(ls);
+		handleLine(ls);
 
 	}
 	while(_confFile.getNext());
 	if (!blockClosed)
 		throw Exception("A block wasn't closed");
-	// check();
+}
+
+void ABlock::handleLineCommon(std::string lineString)
+{
+	if (isPresent(lineString, "root"))
+	{
+		this->_root = getStringDirective(lineString, "root");
+	}
+	else if (isPresent(lineString, "client_max_body_size"))
+	{
+		this->_clientMaxBodySize = parseClientMaxBodySize(lineString);
+	}
+	else if (isPresent(lineString, "autoindex"))
+	{
+		this->_autoindex = parseBoolDirective(lineString, "autoindex");
+	}
+	else if (isPresent(lineString, "index"))
+	{
+		this->_index = ft_split(getStringDirective(lineString, "index"), ' ');
+	}
 }
 
 void ABlock::handleLine(std::string lineString)
@@ -168,8 +209,6 @@ int	ft_atoi(const char *str)
 	return (nbr * sign);
 }
 
-
-// int parse_size(size_t needle, std::string lineString)
 int ABlock::parseClientMaxBodySize(std::string lineString)
 {
 	std::string value = getStringDirective(lineString, "client_max_body_size");
@@ -190,7 +229,6 @@ int ABlock::parseClientMaxBodySize(std::string lineString)
 	return raw_value;
 }
 
-// void Reader::parseFcgiParam(size_t needle)
 void ABlock::parseFastCGIParam(std::string lineString,
 			std::map<std::string, std::string> &params)
 {
@@ -243,4 +281,25 @@ void ABlock::parseListen(std::string lineString, std::string &listenHost,
 		listenHost = "";
 		listenIp = ft_atoi(directive.c_str());
 	}
+}
+
+int ABlock::getClientMaxBodySize(void) const
+{
+	return _clientMaxBodySize;
+}
+
+bool ABlock::getAutoindex(void) const
+{
+	return _autoindex;
+}
+
+std::vector<std::string> ABlock::getIndex(void) const
+{
+	return _index;
+
+}
+
+std::string ABlock::getRoot(void) const
+{
+	return _root;
 }

--- a/src/config/Config.class.cpp
+++ b/src/config/Config.class.cpp
@@ -26,8 +26,10 @@ void Config::handle()
 {
 	do
 	{
-		checkLine(getConfFile().getLineString());
-		handleLine(getConfFile().getLineString());
+		std::string ls = getConfFile().getLineString();
+		checkLine(ls);
+		handleLineCommon(ls);
+		handleLine(ls);
 
 	}
 	while(getConfFile().getNext());
@@ -83,30 +85,31 @@ void Config::handleLine(std::string lineString)
 	if (lineString.find("server") != std::string::npos)
 	{
 		// std::cout << "Found server" << std::endl;
-		VirtualHost sBlock(this->getConfFile());
+		// VirtualHost sBlock(this->getConfFile());
+		VirtualHost sBlock(*this);
 
-		sBlock.inheritParams(this->clientMaxBodySize, this->autoindex,
-			this->root, this->index);
+		// sBlock.inheritParams(this->clientMaxBodySize, this->autoindex,
+			// this->root, this->index);
 		sBlock.handle();
 
 		virtualHostVector.push_back(sBlock);
 	}
-	else if (isPresent(lineString, "client_max_body_size"))
-	{
-		this->clientMaxBodySize = parseClientMaxBodySize(lineString);
-	}
-	else if (isPresent(lineString, "autoindex"))
-	{
-		this->autoindex = parseBoolDirective(lineString, "autoindex");
-	}
-	else if (isPresent(lineString, "index"))
-	{
-		this->index = ft_split(getStringDirective(lineString, "index"), ' ');
-	}
-	else if (isPresent(lineString, "root"))
-	{
-		this->root = getStringDirective(lineString, "root");
-	}
+	// else if (isPresent(lineString, "client_max_body_size"))
+	// {
+	// 	this->clientMaxBodySize = parseClientMaxBodySize(lineString);
+	// }
+	// else if (isPresent(lineString, "autoindex"))
+	// {
+	// 	this->autoindex = parseBoolDirective(lineString, "autoindex");
+	// }
+	// else if (isPresent(lineString, "index"))
+	// {
+	// 	this->index = ft_split(getStringDirective(lineString, "index"), ' ');
+	// }
+	// else if (isPresent(lineString, "root"))
+	// {
+	// 	this->root = getStringDirective(lineString, "root");
+	// }
 }
 
 std::vector<VirtualHost> Config::getVirtualHostVector(void) const
@@ -114,25 +117,25 @@ std::vector<VirtualHost> Config::getVirtualHostVector(void) const
 	return this->virtualHostVector;
 }
 
-int Config::getClientMaxBodySize(void) const
-{
-	return this->clientMaxBodySize;
-}
+// int Config::getClientMaxBodySize(void) const
+// {
+// 	return this->clientMaxBodySize;
+// }
 
-bool Config::getAutoindex(void) const
-{
-	return this->autoindex;
-}
+// bool Config::getAutoindex(void) const
+// {
+// 	return this->autoindex;
+// }
 
-std::vector<std::string> Config::getIndex(void) const
-{
-	return this->index;
-}
+// std::vector<std::string> Config::getIndex(void) const
+// {
+// 	return this->index;
+// }
 
-std::string Config::getRoot(void) const
-{
-	return this->root;
-}
+// std::string Config::getRoot(void) const
+// {
+// 	return this->root;
+// }
 
 
 

--- a/src/config/Config.class.cpp
+++ b/src/config/Config.class.cpp
@@ -69,6 +69,11 @@ void Config::check()
 			
 	}
 
+	for (size_t i = 0; i < virtualHostVector.size(); i++)
+	{
+		virtualHostVector[i].check();
+	}
+
 }
 
 void Config::handleLine(std::string lineString)

--- a/src/config/ConfigFile.class.cpp
+++ b/src/config/ConfigFile.class.cpp
@@ -64,6 +64,7 @@ int ConfigFile::getNext()
 	if (_ret == 0)
 	{
 		_lastLineRead = true;
+		close(_fd);
 		return 1;
 	}
 	return this->_ret;

--- a/src/config/ConfigFile.class.cpp
+++ b/src/config/ConfigFile.class.cpp
@@ -29,22 +29,7 @@ ConfigFile::ConfigFile(std::string filename) :
 	this->_fd = open(filename.c_str(), O_RDONLY);
 	if (_fd < 0)
 		throw Exception("Couldn't open file");
-
-	// while ((ret = fd_get_next_line(fd, &line)))
-	// {
-	// 	// std::cout << "Line read: " << line << std::endl;
-	// 	// assignLineString();
-	// 	this->lineString.assign(line);
-	// 	parse(this->lineString);
-	// }
-	// parse(this->lineString);
 }
-
-// void ConfigFile::next()
-// {
-// 	this->ret = fd_get_next_line(this->fd, &(this->line));
-// 	this->lineString.assign(this->line);
-// }
 
 int ConfigFile::getNext()
 {

--- a/src/config/ConfigReader.class.cpp
+++ b/src/config/ConfigReader.class.cpp
@@ -65,6 +65,8 @@ ConfigReader::ConfigReader(std::string filename) :
 		confFile.getLineString();
 		parse();
 	}
+	//check
+	_config.check();
 
 }
 

--- a/src/config/LimitExcept.class.cpp
+++ b/src/config/LimitExcept.class.cpp
@@ -12,7 +12,7 @@
 
 #include "LimitExcept.class.hpp"
 
-LimitExcept::LimitExcept(ConfigFile &confFile) : ABlock(confFile)
+LimitExcept::LimitExcept(ConfigFile &confFile) : ABlock(confFile), _empty(true)
 {
 }
 
@@ -23,6 +23,7 @@ std::vector<std::string> LimitExcept::parseMethods(std::string line)
 	size_t pattern_end = line.find("{", pattern_start);
 	std::string pattern = line.substr(pattern_start, pattern_end-pattern_start);
 	trimWhitespace(pattern);
+	trimWhitespaceStart(pattern);
 	return ft_split(pattern, ' ');
 }
 
@@ -35,16 +36,19 @@ void LimitExcept::handleLine(std::string lineString)
 	if (isPresent(lineString, "limit_except"))
 	{
 		this->_methods = parseMethods(lineString);
+		this->_empty = false;
 	}
 	if (isPresent(lineString, "allow"))
 	{
 		appendix = ft_split(getStringDirective(lineString, "allow"), ' ');
 		this->_allow.insert(this->_allow.end(), appendix.begin(), appendix.end());
+		this->_empty = false;
 	}
 	if (isPresent(lineString, "deny"))
 	{
 		appendix = ft_split(getStringDirective(lineString, "deny"), ' ');
 		this->_deny.insert(this->_deny.end(), appendix.begin(), appendix.end());
+		this->_empty = false;
 	}
 }
 
@@ -62,4 +66,9 @@ std::vector<std::string> LimitExcept::getDeny(void) const
 std::vector<std::string> LimitExcept::getMethods(void) const
 {
 	return _methods;
+}
+
+bool LimitExcept::isEmpty(void) const
+{
+	return _empty;
 }

--- a/src/config/LimitExcept.class.cpp
+++ b/src/config/LimitExcept.class.cpp
@@ -16,14 +16,14 @@ LimitExcept::LimitExcept(ConfigFile &confFile) : ABlock(confFile)
 {
 }
 
-std::string LimitExcept::parseMethod(std::string line)
+std::vector<std::string> LimitExcept::parseMethods(std::string line)
 {
 	size_t loc_position = line.find("limit_except");
 	size_t pattern_start = loc_position + 13;
 	size_t pattern_end = line.find("{", pattern_start);
 	std::string pattern = line.substr(pattern_start, pattern_end-pattern_start);
 	trimWhitespace(pattern);
-	return pattern;
+	return ft_split(pattern, ' ');
 }
 
 void LimitExcept::handleLine(std::string lineString)
@@ -34,32 +34,32 @@ void LimitExcept::handleLine(std::string lineString)
 
 	if (isPresent(lineString, "limit_except"))
 	{
-		this->method = parseMethod(lineString);
+		this->_methods = parseMethods(lineString);
 	}
 	if (isPresent(lineString, "allow"))
 	{
 		appendix = ft_split(getStringDirective(lineString, "allow"), ' ');
-		this->allow.insert(this->allow.end(), appendix.begin(), appendix.end());
+		this->_allow.insert(this->_allow.end(), appendix.begin(), appendix.end());
 	}
 	if (isPresent(lineString, "deny"))
 	{
 		appendix = ft_split(getStringDirective(lineString, "deny"), ' ');
-		this->deny.insert(this->deny.end(), appendix.begin(), appendix.end());
+		this->_deny.insert(this->_deny.end(), appendix.begin(), appendix.end());
 	}
 }
 
 
 std::vector<std::string> LimitExcept::getAllow(void) const
 {
-	return allow;
+	return _allow;
 }
 
 std::vector<std::string> LimitExcept::getDeny(void) const
 {
-	return deny;
+	return _deny;
 }
 
-std::string LimitExcept::getMethod(void) const
+std::vector<std::string> LimitExcept::getMethods(void) const
 {
-	return method;
+	return _methods;
 }

--- a/src/config/Location.class.cpp
+++ b/src/config/Location.class.cpp
@@ -55,6 +55,10 @@ void Location::check()
 		throw Exception("Root and fcgi_pass on the same location.");
 	if (fcgiSet == true && uploadStoreSet == true)
 		throw Exception("Upload_store and fcgi_pass on the same location.");
+
+	if (!this->limitExcept.isEmpty() &&
+			this->limitExcept.getMethods().size() == 0)
+		throw Exception("limit_except must specify at least one method.");
 }
 
 // void Location::inheritParams(ABlock *parent)

--- a/src/config/Location.class.cpp
+++ b/src/config/Location.class.cpp
@@ -19,6 +19,11 @@ Location::Location(ConfigFile &confFile) : ABlock(confFile), limitExcept(confFil
 	this->uploadStoreSet = false;
 }
 
+Location::Location(ABlock &ab) : ABlock(ab), limitExcept(ab.getConfFile())
+{
+
+}
+
 /*
 ** Parse a pattern from the first line of a location block.
 ** From this line:
@@ -39,15 +44,14 @@ std::string Location::parsePattern(std::string line)
 	return pattern;
 }
 
-void Location::inheritParams(int _clientMaxBodySize, bool _autoindex,
-		std::string _root, std::vector<std::string> _index, std::string _uploadStore)
-{
-	this->clientMaxBodySize = _clientMaxBodySize;
-	this->autoindex = _autoindex;
-	this->root = _root;
-	this->index = _index;
-	this->uploadStore = _uploadStore;
-}
+// void Location::inheritParams(int _clientMaxBodySize, bool _autoindex,
+// 		std::string root, std::vector<std::string> _index, std::string _uploadStore)
+// {
+// 	this->clientMaxBodySize = _clientMaxBodySize;
+// 	this->autoindex = _autoindex;
+// 	this->index = _index;
+// 	this->uploadStore = _uploadStore;
+// }
 
 void Location::check()
 {
@@ -80,20 +84,12 @@ void Location::handleLine(std::string lineString)
 
 	if (isPresent(lineString, "root"))
 	{
-		this->root = getStringDirective(lineString, "root");
+		// this->root = getStringDirective(lineString, "root");
 		this->rootSet = true;
 	}
 	if (isPresent(lineString, "location"))
 	{
 		this->pattern = parsePattern(lineString);
-	}
-	if (isPresent(lineString, "client_max_body_size"))
-	{
-		this->clientMaxBodySize = parseClientMaxBodySize(lineString);
-	}
-	if (isPresent(lineString, "autoindex"))
-	{
-		this->autoindex = parseBoolDirective(lineString, "autoindex");
 	}
 	if (isPresent(lineString, "fastcgi_pass"))
 	{
@@ -103,10 +99,6 @@ void Location::handleLine(std::string lineString)
 	if (isPresent(lineString, "fastcgi_param"))
 	{
 		parseFastCGIParam(lineString, this->fcgiParams);
-	}
-	else if (isPresent(lineString, "index"))
-	{
-		this->index = ft_split(getStringDirective(lineString, "index"), ' ');
 	}
 	else if (isPresent(lineString, "upload_store"))
 	{
@@ -120,25 +112,25 @@ std::string Location::getPattern(void) const
 	return this->pattern;
 }
 
-std::string Location::getRoot(void) const
-{
-	return this->root;
-}
+// std::string Location::getRoot(void) const
+// {
+// 	return this->root;
+// }
 
-int Location::getClientMaxBodySize(void) const 
-{
-	return this->clientMaxBodySize;
-}
+// int Location::getClientMaxBodySize(void) const 
+// {
+// 	return this->clientMaxBodySize;
+// }
 
-bool Location::getAutoindex(void) const
-{
-	return this->autoindex;
-}
+// bool Location::getAutoindex(void) const
+// {
+// 	return this->autoindex;
+// }
 
-std::vector<std::string> Location::getIndex(void) const
-{
-	return this->index;
-}
+// std::vector<std::string> Location::getIndex(void) const
+// {
+// 	return this->index;
+// }
 
 LimitExcept Location::getLimitExcept(void) const
 {
@@ -173,4 +165,9 @@ bool Location::getFcgiSet(void) const
 bool Location::getUploadStoreSet(void) const
 {
 	return this->uploadStoreSet;
+}
+
+void Location::setUploadStore(std::string _uploadStore)
+{
+	this->uploadStore = _uploadStore;
 }

--- a/src/config/VirtualHost.class.cpp
+++ b/src/config/VirtualHost.class.cpp
@@ -16,15 +16,21 @@ VirtualHost::VirtualHost(ConfigFile &confFile) : ABlock(confFile)
 {
 }
 
+VirtualHost::VirtualHost(ABlock &ab) : ABlock(ab)
+{
+}
+
 void VirtualHost::handleLine(std::string lineString)
 {
 	// std::cout << "VirtualHost handled: " << lineString << std::endl;
 	if (lineString.find("location") != std::string::npos)
 	{
-		Location locBlock(this->getConfFile());
+		Location locBlock(*this);
 
-		locBlock.inheritParams(this->clientMaxBodySize, this->autoindex,
-			this->root, this->index, this->uploadStore);
+		locBlock.setUploadStore(this->uploadStore);
+
+		// locBlock.inheritParams(this->clientMaxBodySize, this->autoindex,
+			// this->root, this->index, this->uploadStore);
 
 		locBlock.handle();
 
@@ -40,36 +46,24 @@ void VirtualHost::handleLine(std::string lineString)
 		this->serverName = ft_split(getStringDirective(lineString,
 										"server_name"), ' ');
 	}
-	else if (isPresent(lineString, "client_max_body_size"))
-	{
-		this->clientMaxBodySize = parseClientMaxBodySize(lineString);
-	}
-	else if (isPresent(lineString, "autoindex"))
-	{
-		this->autoindex = parseBoolDirective(lineString, "autoindex");
-	}
-	else if (isPresent(lineString, "index"))
-	{
-		this->index = ft_split(getStringDirective(lineString, "index"), ' ');
-	}
 	else if (isPresent(lineString, "upload_store"))
 	{
 		this->uploadStore = getStringDirective(lineString, "upload_store");
 	}
-	else if (isPresent(lineString, "root"))
-	{
-		this->root = getStringDirective(lineString, "root");
-	}
+	// else if (isPresent(lineString, "root"))
+	// {
+	// 	this->root = getStringDirective(lineString, "root");
+	// }
 }
 
-void VirtualHost::inheritParams(int _clientMaxBodySize, bool _autoindex,
-		std::string _root, std::vector<std::string> _index)
-{
-	this->clientMaxBodySize = _clientMaxBodySize;
-	this->autoindex = _autoindex;
-	this->root = _root;
-	this->index = _index;
-}
+// void VirtualHost::inheritParams(int _clientMaxBodySize, bool _autoindex,
+// 		std::string _root, std::vector<std::string> _index)
+// {
+// 	this->clientMaxBodySize = _clientMaxBodySize;
+// 	this->autoindex = _autoindex;
+// 	this->root = _root;
+// 	this->index = _index;
+// }
 
 int VirtualHost::getListenIp(void) const
 {
@@ -91,30 +85,30 @@ std::vector<Location> VirtualHost::getLocations(void) const
 	return this->locations;
 }
 
-int VirtualHost::getClientMaxBodySize(void) const
-{
-	return this->clientMaxBodySize;
-}
+// int VirtualHost::getClientMaxBodySize(void) const
+// {
+// 	return this->clientMaxBodySize;
+// }
 
-bool VirtualHost::getAutoindex(void) const
-{
-	return this->autoindex;
-}
+// bool VirtualHost::getAutoindex(void) const
+// {
+// 	return this->autoindex;
+// }
 
-std::vector<std::string> VirtualHost::getIndex(void) const
-{
-	return this->index;
-}
+// std::vector<std::string> VirtualHost::getIndex(void) const
+// {
+// 	return this->index;
+// }
 
 std::string VirtualHost::getUploadStore(void) const
 {
 	return this->uploadStore;
 }
 
-std::string VirtualHost::getRoot(void) const
-{
-	return this->root;
-}
+// std::string VirtualHost::getRoot(void) const
+// {
+// 	return this->root;
+// }
 
 void VirtualHost::check(void)
 {

--- a/src/config/VirtualHost.class.cpp
+++ b/src/config/VirtualHost.class.cpp
@@ -115,3 +115,12 @@ std::string VirtualHost::getRoot(void) const
 {
 	return this->root;
 }
+
+void VirtualHost::check(void)
+{
+	// specific checks
+	for (size_t i = 0; i < locations.size(); i++)
+	{
+		locations[i].check();
+	}
+}

--- a/tests/config/test_configs/fake_limit_except.conf
+++ b/tests/config/test_configs/fake_limit_except.conf
@@ -1,0 +1,7 @@
+server {
+	location /app/ {
+	
+		limit_except {
+		}
+	}
+}

--- a/tests/config/test_configs/nginx.conf
+++ b/tests/config/test_configs/nginx.conf
@@ -51,3 +51,16 @@ server {
         autoindex off;
     }
 }
+
+server {
+    listen       127.0.0.2:443;
+    server_name  domain3.com www.domain3.com;
+    client_max_body_size    1024;
+
+    location /app/ {
+        root   /var/www/;
+        limit_except GET POST {
+            allow all;
+        }
+    }
+}

--- a/tests/config/unit_tests.cpp
+++ b/tests/config/unit_tests.cpp
@@ -6,7 +6,7 @@
 /*   By: ashishae <ashishae@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/12/17 17:45:02 by ashishae          #+#    #+#             */
-/*   Updated: 2021/02/17 16:01:26 by ashishae         ###   ########.fr       */
+/*   Updated: 2021/02/18 12:49:56 by ashishae         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -91,7 +91,7 @@ int main(void)
 
 
 	std::vector<VirtualHost> virtualHostVector = conf.getVirtualHostVector();
-	check(virtualHostVector.size() == 3);
+	check(virtualHostVector.size() == 4);
 
 	out("Config | Root");
 	check(conf.getRoot() == "/var/www/");
@@ -141,7 +141,8 @@ int main(void)
 
 	check(virtualHostVector[1].getLocations()[0].getRoot() == "/var/www/");
 	out("Host 1 | Location 0 | limit_except ");
-	check(virtualHostVector[1].getLocations()[0].getLimitExcept().getMethod() == "GET");
+	check(virtualHostVector[1].getLocations()[0].getLimitExcept().getMethods().size() == 1);
+	check(virtualHostVector[1].getLocations()[0].getLimitExcept().getMethods()[0] == "GET");
 	check(virtualHostVector[1].getLocations()[0].getLimitExcept().getAllow().size() == 2);
 	check(virtualHostVector[1].getLocations()[0].getLimitExcept().getAllow()[0] == "127.0.0.1");
 	check(virtualHostVector[1].getLocations()[0].getLimitExcept().getAllow()[1] == "127.0.0.2");
@@ -178,6 +179,11 @@ int main(void)
 
 	out("Host 2 | Location 1 | autoindex off");
 	check(virtualHostVector[2].getLocations()[1].getAutoindex() == false);
+
+	out("Host 3 | Location 0 | limit_except with multiple methods");
+	check(virtualHostVector[3].getLocations()[0].getLimitExcept().getMethods().size() == 2);
+	check(virtualHostVector[3].getLocations()[0].getLimitExcept().getMethods()[0] == "GET");
+	check(virtualHostVector[3].getLocations()[0].getLimitExcept().getMethods()[1] == "POST");
 
 	out("Exception | Missing semicolon");
 	TEST_EXCEPTION(ConfigReader r2("./config/test_configs/unfinished_directive.conf"), Exception, "A semicolon is missing");

--- a/tests/config/unit_tests.cpp
+++ b/tests/config/unit_tests.cpp
@@ -6,7 +6,7 @@
 /*   By: ashishae <ashishae@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/12/17 17:45:02 by ashishae          #+#    #+#             */
-/*   Updated: 2021/02/19 10:54:37 by ashishae         ###   ########.fr       */
+/*   Updated: 2021/02/19 11:41:34 by ashishae         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,50 +19,52 @@
 
 #include <iostream>
 
-bool exception_thrown = false;
+// bool exception_thrown = false;
 
-void check(int expression);
+// void check(int expression);
 
-#define TEST_EXCEPTION(expression, exceptionType, exceptionString) { \
-	exception_thrown = false; \
-	try \
-	{ \
-		expression; \
-	} \
-	catch (const exceptionType &e) \
-	{ \
-		exception_thrown = true; \
-		check((!strcmp(e.what(), exceptionString))); \
-		std::cout << e.what() << std::endl;\
-	} \
-	if (!exception_thrown)\
-		std::cout << "Exception NOT thrown" << std::endl; \
-	check(exception_thrown == true); \
-}
+// #define TEST_EXCEPTION(expression, exceptionType, exceptionString) { \
+// 	exception_thrown = false; \
+// 	try \
+// 	{ \
+// 		expression; \
+// 	} \
+// 	catch (const exceptionType &e) \
+// 	{ \
+// 		exception_thrown = true; \
+// 		check((!strcmp(e.what(), exceptionString))); \
+// 		std::cout << e.what() << std::endl;\
+// 	} \
+// 	if (!exception_thrown)\
+// 		std::cout << "Exception NOT thrown" << std::endl; \
+// 	check(exception_thrown == true); \
+// }
 
-int test_no = 1;
+// int test_no = 1;
 
-void out(std::string s)
-{
-	std::cout << std::endl;
-	std::cout << "\033[0;34m" << "Test " << test_no << " | " << s << "\033[0m" << std::endl;
-	test_no += 1;
-}
+// void out(std::string s)
+// {
+// 	std::cout << std::endl;
+// 	std::cout << "\033[0;34m" << "Test " << test_no << " | " << s << "\033[0m" << std::endl;
+// 	test_no += 1;
+// }
 
-void check(int expression)
-{
-	// If expression doesn't evaluate to 1, the program will abort
-	// assert(expression == 1);
-	if (expression == 1)
-	{
-		std::cout << "\033[92m✓ PASS\033[0m" << std::endl;
-	}
-	else 
-	{
-		std::cout << "\033[91m✓ FAIL\033[0m" << std::endl;
-	}
+// void check(int expression)
+// {
+// 	// If expression doesn't evaluate to 1, the program will abort
+// 	// assert(expression == 1);
+// 	if (expression == 1)
+// 	{
+// 		std::cout << "\033[92m✓ PASS\033[0m" << std::endl;
+// 	}
+// 	else 
+// 	{
+// 		std::cout << "\033[91m✓ FAIL\033[0m" << std::endl;
+// 	}
 	
-}
+// }
+
+# include "femtotest.hpp"
 
 #include "VirtualHost.class.hpp"
 #include "ConfigReader.class.hpp"
@@ -242,6 +244,10 @@ int main(void)
 	check(res.size() == 2);
 	check(res[0] == "hello");
 	check(res[1] == "world");
+
+
+	test_results();
+
 
 	// TEST_EXCEPTION(ConfigReader r2("missing_listen.conf"), virtualHost::DirectiveNotFound,\
 	// 				"A required directive wasn't found in a context.");

--- a/tests/config/unit_tests.cpp
+++ b/tests/config/unit_tests.cpp
@@ -6,7 +6,7 @@
 /*   By: ashishae <ashishae@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/12/17 17:45:02 by ashishae          #+#    #+#             */
-/*   Updated: 2021/02/18 12:49:56 by ashishae         ###   ########.fr       */
+/*   Updated: 2021/02/19 10:54:37 by ashishae         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -117,6 +117,9 @@ int main(void)
 	check(virtualHostVector[0].getLocations()[0].getPattern() == "/");
 	check(virtualHostVector[0].getLocations()[0].getRoot() == "/var/www/");
 
+	out("Host 0 | location 0 | no limit except");
+	check(virtualHostVector[0].getLocations()[0].getLimitExcept().isEmpty() == true);
+
 	check(virtualHostVector[0].getClientMaxBodySize() == 32);
 
 	out("Host 0 | Root inherited from config");
@@ -224,6 +227,21 @@ int main(void)
 
 	out("Exception | upload and fcgi on same location");
 	TEST_EXCEPTION(ConfigReader r3("./config/test_configs/upload_and_fcgi.conf"), Exception, "Upload_store and fcgi_pass on the same location.");
+
+	out("Exception | limit_except without method");
+	TEST_EXCEPTION(ConfigReader r3("./config/test_configs/fake_limit_except.conf"), Exception, "limit_except must specify at least one method.");
+
+	out("Ft_split | empty string");
+	check(ft_split("", ' ').size() == 0);
+
+	out("Ft_split | normal string");
+	std::string s1("hello world");
+	std::vector<std::string> res;
+
+	res = ft_split(s1, ' ');
+	check(res.size() == 2);
+	check(res[0] == "hello");
+	check(res[1] == "world");
 
 	// TEST_EXCEPTION(ConfigReader r2("missing_listen.conf"), virtualHost::DirectiveNotFound,\
 	// 				"A required directive wasn't found in a context.");

--- a/tests/test_config.sh
+++ b/tests/test_config.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-clang++ ../src/config/*.cpp ./config/unit_tests.cpp ../src/get_next_line/*.cpp -I ../inc/ -o config_test -Wall -Wextra -Werror && ./config_test ; rm config_test
+clang++ ../src/config/*.cpp ./config/unit_tests.cpp ../src/get_next_line/*.cpp ../src/Utility.cpp -I ../inc/ -o config_test -Wall -Wextra -Werror && ./config_test ; rm config_test

--- a/tests/test_config.sh
+++ b/tests/test_config.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
-clang++ ../src/config/*.cpp ./config/unit_tests.cpp ../src/get_next_line/*.cpp ../src/Utility.cpp -I ../inc/ -o config_test -Wall -Wextra -Werror && ./config_test ; rm config_test
+clang++ ../src/config/*.cpp ./config/unit_tests.cpp ../src/get_next_line/*.cpp ../src/Utility.cpp -I ../inc/ -o config_test -Wall -Wextra -Werror && ./config_test
+rm config_test


### PR DESCRIPTION
LimitExcept now has getMethods instead of getMethod:

```std::vector<std::string> LimitExcept::getMethods(void) const;```


It also now has a method to determine if it is empty:

```bool LimitExcept::isEmpty(void) const;```

(You can get the same result by checking the size of methods. A non-empty LimitExcept can't have 0 methods).