### PR TITLE
Add error_page to config

### DIFF
--- a/inc/ABlock.class.hpp
+++ b/inc/ABlock.class.hpp
@@ -47,6 +47,8 @@ public:
 
 	void insertErrorPages(std::map<int, std::string> &newErrorPages);
 
+	void parseErrorPage(std::string directiveValue);
+
 	static bool isPresent(std::string lineString, std::string keyword);
 
 	static std::string getStringDirective(std::string lineString, std::string key);
@@ -63,7 +65,6 @@ public:
 	static int countOccurence(std::string s, char c);
 
 	static void checkLine(std::string lineString);
-	static std::map<int, std::string> parseErrorPage(std::string directiveValue);
 
 
 	virtual ~ABlock();

--- a/inc/ABlock.class.hpp
+++ b/inc/ABlock.class.hpp
@@ -18,6 +18,7 @@
 
 # include <vector>
 # include <map>
+# include <algorithm>
 # include "Utility.hpp"
 
 class ABlock
@@ -44,6 +45,8 @@ public:
 
 	virtual void check(void);
 
+	void insertErrorPages(std::map<int, std::string> &newErrorPages);
+
 	static bool isPresent(std::string lineString, std::string keyword);
 
 	static std::string getStringDirective(std::string lineString, std::string key);
@@ -60,12 +63,16 @@ public:
 	static int countOccurence(std::string s, char c);
 
 	static void checkLine(std::string lineString);
+	static std::map<int, std::string> parseErrorPage(std::string directiveValue);
+
+
 	virtual ~ABlock();
 
 	int getClientMaxBodySize(void) const;
 	bool getAutoindex(void) const;
 	std::vector<std::string> getIndex(void) const;
 	std::string getRoot(void) const;
+	std::map<int, std::string> getErrorPage(void) const;
 
 private:
 	ConfigFile &_confFile;
@@ -74,6 +81,7 @@ private:
 	bool _autoindex;
 	std::vector<std::string> _index;
 	std::string _root;
+	std::map<int, std::string> _errorPage;
 
 
 

--- a/inc/ConfigFile.class.hpp
+++ b/inc/ConfigFile.class.hpp
@@ -29,6 +29,7 @@ public:
 	// void next();
 	int getNext();
 	std::string getLineString(void) const;
+	void rewind(void);
 
 private:
 	int _fd;

--- a/inc/Location.class.hpp
+++ b/inc/Location.class.hpp
@@ -57,7 +57,7 @@ public:
 
 private:
 
-	static std::string parsePattern(std::string line);
+	std::string parsePattern(std::string line);
 
 	std::string pattern;
 	

--- a/inc/Utility.hpp
+++ b/inc/Utility.hpp
@@ -14,5 +14,6 @@ std::string					readFile(std::string file);
 std::string					replacehtml(std::string src, std::string var, std::string value);
 time_t						getTime();
 std::vector<std::string>	ft_split(std::string, char delimiter);
+int							ft_atoi(const char *str);
 
 #endif

--- a/inc/femtotest.hpp
+++ b/inc/femtotest.hpp
@@ -6,7 +6,7 @@
 /*   By: ashishae <ashishae@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/31 12:17:05 by ashishae          #+#    #+#             */
-/*   Updated: 2021/02/19 11:43:49 by ashishae         ###   ########.fr       */
+/*   Updated: 2021/03/02 13:20:49 by ashishae         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,10 +37,20 @@ void check(int expression);
 	catch (const exceptionType &e) \
 	{ \
 		exception_thrown = true; \
-		check((!strcmp(e.what(), exceptionString))); \
+		bool messageEqual = !strcmp(e.what(), exceptionString); \
+		check(messageEqual == true); \
+		if (!messageEqual) \
+		{ \
+			std::cout << "Expected exception: " << exceptionString \
+				<< ", but got: " << e.what() << std::endl;\
+		} \
 		std::cout << e.what() << std::endl;\
 	} \
 	check(exception_thrown == true); \
+	if (!exception_thrown)\
+	{\
+		std::cout << "Exception not thrown when expected" << std::endl;\
+	}\
 }
 
 int test_no = 1;

--- a/src/Utility.cpp
+++ b/src/Utility.cpp
@@ -90,3 +90,28 @@ time_t			getTime()
 	gettimeofday(&tv, &tz);
 	return (tv.tv_sec + tz.tz_minuteswest * 60);
 }
+
+// TODO : test some more
+int	ft_atoi(const char *str)
+{
+	int		nbr;
+	int		sign;
+
+	nbr = 0;
+	sign = 1;
+	while ((*str) == '\t' || (*str) == '\n' || (*str) == '\v' || (*str) == '\f'
+			|| (*str) == '\r' || (*str) == ' ')
+		str++;
+	if ((*str) == '-' || (*str) == '+')
+	{
+		sign *= ((*str) == '-' ? -1 : 1);
+		str++;
+	}
+	while ((*str) != '\0' && (*str) >= '0' && (*str) <= '9')
+	{
+		nbr *= 10;
+		nbr += (*str) - '0';
+		str++;
+	}
+	return (nbr * sign);
+}

--- a/src/config/ABlock.class.cpp
+++ b/src/config/ABlock.class.cpp
@@ -12,17 +12,6 @@
 
 #include "ABlock.class.hpp"
 
-// const std::string ABlock::blockStartKeyword = "server";
-
-// bool ABlock::blockStarted(std::string lineString)
-// {
-// 	size_t pos;
-// 	if ((pos = lineString.find(blockStartKeyword)) != std::string::npos)
-// 	{
-// 		return true;
-// 	}
-// 	return false;
-// }
 
 ABlock::ABlock(ConfigFile &confFile) :
 	_confFile(confFile),
@@ -31,22 +20,6 @@ ABlock::ABlock(ConfigFile &confFile) :
 	_index(std::vector<std::string>())
 {
 }
-
-// ABlock::ABlock(ABlock &ab) :
-// 	_confFile(ab._confFile),
-// 	_clientMaxBodySize(ab._clientMaxBodySize),
-// 	_autoindex(ab._autoindex),
-// 	_index(ab._index)
-// {
-// }
-
-// ABlock::ABlock(ABlock *ab) :
-// 	_confFile(ab->_confFile),
-// 	_clientMaxBodySize(ab->_clientMaxBodySize),
-// 	_autoindex(ab->_autoindex),
-// 	_index(ab->_index)
-// {
-// }
 
 
 int ABlock::countOccurence(std::string s, char c)

--- a/src/config/ABlock.class.cpp
+++ b/src/config/ABlock.class.cpp
@@ -68,21 +68,23 @@ void ABlock::handle()
 		throw Exception("A block wasn't closed");
 }
 
-std::map<int, std::string> ABlock::parseErrorPage(std::string directiveValue)
+void ABlock::parseErrorPage(std::string directiveValue)
 {
 	std::map<int, std::string> ret;
 
 	std::vector<std::string> directiveParts = ft_split(directiveValue, ' ');
 
 	if (directiveParts.size() < 2)
+	{
+		_confFile.rewind();
 		throw Exception("error_page has to specify error code and page.");
+	}
 
 	for (size_t i = 0; i < directiveParts.size()-1; i++)
 	{
 		ret[ft_atoi(directiveParts[i].c_str())] = directiveParts[directiveParts.size()-1];
 	}
-
-	return ret;
+	insertErrorPages(ret);
 }
 
 /*
@@ -115,9 +117,9 @@ void ABlock::handleLineCommon(std::string lineString)
 	}
 	else if (isPresent(lineString, "error_page"))
 	{
-		std::map<int, std::string> newErrorMap = parseErrorPage(getStringDirective(lineString, "error_page"));
+		parseErrorPage(getStringDirective(lineString, "error_page"));
 		// this->_errorPage.insert(newErrorMap.begin(), newErrorMap.end());
-		insertErrorPages(newErrorMap);
+		// insertErrorPages(newErrorMap);
 	}
 }
 

--- a/src/config/ABlock.class.cpp
+++ b/src/config/ABlock.class.cpp
@@ -115,7 +115,6 @@ void ABlock::handleLineCommon(std::string lineString)
 	}
 	else if (isPresent(lineString, "error_page"))
 	{
-		std::cout << "Error page dir: |" << getStringDirective(lineString, "error_page") << "|" << std::endl;
 		std::map<int, std::string> newErrorMap = parseErrorPage(getStringDirective(lineString, "error_page"));
 		// this->_errorPage.insert(newErrorMap.begin(), newErrorMap.end());
 		insertErrorPages(newErrorMap);

--- a/src/config/ConfigFile.class.cpp
+++ b/src/config/ConfigFile.class.cpp
@@ -59,6 +59,11 @@ std::string ConfigFile::getLineString(void) const
 {
 	if (this->_fd < 0)
 		throw Exception("File not open");
-
 	return this->_lineString;
+}
+
+void ConfigFile::rewind(void)
+{
+	while (this->getNext())
+		continue;
 }

--- a/src/config/LimitExcept.class.cpp
+++ b/src/config/LimitExcept.class.cpp
@@ -52,7 +52,6 @@ void LimitExcept::handleLine(std::string lineString)
 	}
 }
 
-
 std::vector<std::string> LimitExcept::getAllow(void) const
 {
 	return _allow;

--- a/src/config/Location.class.cpp
+++ b/src/config/Location.class.cpp
@@ -41,6 +41,8 @@ std::string Location::parsePattern(std::string line)
 	size_t pattern_end = line.find("{", pattern_start);
 	std::string pattern = line.substr(pattern_start, pattern_end-pattern_start);
 	trimWhitespace(pattern);
+	if (pattern.size() == 0)
+		throw Exception("location has to have a pattern.");
 	return pattern;
 }
 

--- a/src/config/Location.class.cpp
+++ b/src/config/Location.class.cpp
@@ -42,7 +42,10 @@ std::string Location::parsePattern(std::string line)
 	std::string pattern = line.substr(pattern_start, pattern_end-pattern_start);
 	trimWhitespace(pattern);
 	if (pattern.size() == 0)
+	{
+		this->getConfFile().rewind();
 		throw Exception("location has to have a pattern.");
+	}
 	return pattern;
 }
 
@@ -65,6 +68,10 @@ void Location::check()
 	if (!this->limitExcept.isEmpty() &&
 			this->limitExcept.getMethods().size() == 0)
 		throw Exception("limit_except must specify at least one method.");
+
+	std::cout << "Location: root: " << this->getRoot() <<", fp: " << this->fcgiPass << ", us: " << this->uploadStore << std::endl;
+	if (this->getRoot() == "" && this->fcgiPass == "" && this->uploadStore == "")
+		throw Exception("location has to specify either root, fastcgi_pass or upload.");
 }
 
 // void Location::inheritParams(ABlock *parent)

--- a/tests/config/config_test_main.cpp
+++ b/tests/config/config_test_main.cpp
@@ -6,7 +6,7 @@
 /*   By: ashishae <ashishae@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/12/17 17:45:02 by ashishae          #+#    #+#             */
-/*   Updated: 2021/02/19 11:41:34 by ashishae         ###   ########.fr       */
+/*   Updated: 2021/03/02 12:54:59 by ashishae         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,55 +14,9 @@
 // Test-related stuff below
 
 // Needed to automatically fail tests;
-#include <assert.h>
-#include <string>
 
 #include <iostream>
 
-// bool exception_thrown = false;
-
-// void check(int expression);
-
-// #define TEST_EXCEPTION(expression, exceptionType, exceptionString) { \
-// 	exception_thrown = false; \
-// 	try \
-// 	{ \
-// 		expression; \
-// 	} \
-// 	catch (const exceptionType &e) \
-// 	{ \
-// 		exception_thrown = true; \
-// 		check((!strcmp(e.what(), exceptionString))); \
-// 		std::cout << e.what() << std::endl;\
-// 	} \
-// 	if (!exception_thrown)\
-// 		std::cout << "Exception NOT thrown" << std::endl; \
-// 	check(exception_thrown == true); \
-// }
-
-// int test_no = 1;
-
-// void out(std::string s)
-// {
-// 	std::cout << std::endl;
-// 	std::cout << "\033[0;34m" << "Test " << test_no << " | " << s << "\033[0m" << std::endl;
-// 	test_no += 1;
-// }
-
-// void check(int expression)
-// {
-// 	// If expression doesn't evaluate to 1, the program will abort
-// 	// assert(expression == 1);
-// 	if (expression == 1)
-// 	{
-// 		std::cout << "\033[92m✓ PASS\033[0m" << std::endl;
-// 	}
-// 	else 
-// 	{
-// 		std::cout << "\033[91m✓ FAIL\033[0m" << std::endl;
-// 	}
-	
-// }
 
 # include "femtotest.hpp"
 

--- a/tests/config/config_test_main.cpp
+++ b/tests/config/config_test_main.cpp
@@ -1,12 +1,12 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   unit_tests.cpp                                     :+:      :+:    :+:   */
+/*   config_test_main.cpp                               :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: ashishae <ashishae@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/12/17 17:45:02 by ashishae          #+#    #+#             */
-/*   Updated: 2021/03/02 12:54:59 by ashishae         ###   ########.fr       */
+/*   Updated: 2021/03/02 13:54:03 by ashishae         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,11 +52,22 @@ int main(void)
 	out("Config | Root");
 	check(conf.getRoot() == "/var/www/");
 
+	out("Config | error_pages");
+	check(conf.getErrorPage()[404] == "/404.html");
+	check(conf.getErrorPage()[500] == "/50x.html");
+	check(conf.getErrorPage()[502] == "/50x.html");
+	check(conf.getErrorPage()[503] == "/50x.html");
+	check(conf.getErrorPage()[504] == "/50x.html");
+	
+
 	out("Host 0 | Listen");
 	check(virtualHostVector[0].getListenIp() == 80);
 	check(virtualHostVector[0].getListenHost() == "");
 
-
+	out("Host 0 | Error page on host");
+	check(virtualHostVector[0].getErrorPage()[404] == "/404_custom.html");
+	check(virtualHostVector[0].getErrorPage()[500] == "/50x.html");
+	std::cout << virtualHostVector[0].getErrorPage()[404] << std::endl;
 
 	check(virtualHostVector[0].getServerName().size() == 2);
 	check(virtualHostVector[0].getServerName()[0] == "domain1.com");
@@ -76,6 +87,14 @@ int main(void)
 	out("Host 0 | location 0 | no limit except");
 	check(virtualHostVector[0].getLocations()[0].getLimitExcept().isEmpty() == true);
 
+	out("Host 0 | location 0 | error_page on location");
+	check(virtualHostVector[0].getLocations()[0].getErrorPage()[42] == "/dontpanic.html");
+	check(virtualHostVector[0].getLocations()[0].getErrorPage()[404] == "/404_custom.html");
+	check(virtualHostVector[0].getLocations()[0].getErrorPage()[500] == "/50x.html");
+	check(virtualHostVector[0].getLocations()[0].getErrorPage()[502] == "/50x.html");
+	check(virtualHostVector[0].getLocations()[0].getErrorPage()[503] == "/50x.html");
+	check(virtualHostVector[0].getLocations()[0].getErrorPage()[504] == "/50x.html");
+	
 	check(virtualHostVector[0].getClientMaxBodySize() == 32);
 
 	out("Host 0 | Root inherited from config");
@@ -187,6 +206,9 @@ int main(void)
 	out("Exception | limit_except without method");
 	TEST_EXCEPTION(ConfigReader r3("./config/test_configs/fake_limit_except.conf"), Exception, "limit_except must specify at least one method.");
 
+	out("Exception | error_pages has != 2 fields");
+	TEST_EXCEPTION(ConfigReader r3("./config/test_configs/error_page_wrong_format.conf"), Exception, "error_page has to specify error code and page.");
+
 	out("Ft_split | empty string");
 	check(ft_split("", ' ').size() == 0);
 
@@ -198,6 +220,16 @@ int main(void)
 	check(res.size() == 2);
 	check(res[0] == "hello");
 	check(res[1] == "world");
+
+
+	out("Ft_split | one field");
+	std::string s2("hello");
+	std::vector<std::string> res2;
+
+	res2 = ft_split(s2, ' ');
+	check(res2.size() == 1);
+	check(res2[0] == "hello");
+
 
 
 	test_results();

--- a/tests/config/config_test_main.cpp
+++ b/tests/config/config_test_main.cpp
@@ -6,7 +6,7 @@
 /*   By: ashishae <ashishae@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/12/17 17:45:02 by ashishae          #+#    #+#             */
-/*   Updated: 2021/03/02 14:10:47 by ashishae         ###   ########.fr       */
+/*   Updated: 2021/03/02 14:24:53 by ashishae         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -211,6 +211,9 @@ int main(void)
 
 	out("Exception | location with empty or no pattern");
 	TEST_EXCEPTION(ConfigReader r3("./config/test_configs/location_without_pattern.conf"), Exception, "location has to have a pattern.");
+
+	out("Exception | location has to specify either root, fastcgi_pass or upload");
+	TEST_EXCEPTION(ConfigReader r3("./config/test_configs/location_without_action.conf"), Exception, "location has to specify either root, fastcgi_pass or upload.");
 
 	out("Ft_split | empty string");
 	check(ft_split("", ' ').size() == 0);

--- a/tests/config/config_test_main.cpp
+++ b/tests/config/config_test_main.cpp
@@ -6,7 +6,7 @@
 /*   By: ashishae <ashishae@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/12/17 17:45:02 by ashishae          #+#    #+#             */
-/*   Updated: 2021/03/02 13:54:03 by ashishae         ###   ########.fr       */
+/*   Updated: 2021/03/02 14:10:47 by ashishae         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -208,6 +208,9 @@ int main(void)
 
 	out("Exception | error_pages has != 2 fields");
 	TEST_EXCEPTION(ConfigReader r3("./config/test_configs/error_page_wrong_format.conf"), Exception, "error_page has to specify error code and page.");
+
+	out("Exception | location with empty or no pattern");
+	TEST_EXCEPTION(ConfigReader r3("./config/test_configs/location_without_pattern.conf"), Exception, "location has to have a pattern.");
 
 	out("Ft_split | empty string");
 	check(ft_split("", ' ').size() == 0);

--- a/tests/config/test_configs/empty_limit_except.conf
+++ b/tests/config/test_configs/empty_limit_except.conf
@@ -1,0 +1,8 @@
+server {
+	location / {
+		root /var/www/;
+		limit_except {
+			...
+		}
+	}
+}

--- a/tests/config/test_configs/error_page_wrong_format.conf
+++ b/tests/config/test_configs/error_page_wrong_format.conf
@@ -1,0 +1,3 @@
+server {
+	error_page 404.html;
+}

--- a/tests/config/test_configs/location_without_action.conf
+++ b/tests/config/test_configs/location_without_action.conf
@@ -1,0 +1,4 @@
+server {
+	location / {
+	}
+}

--- a/tests/config/test_configs/location_without_pattern.conf
+++ b/tests/config/test_configs/location_without_pattern.conf
@@ -1,0 +1,5 @@
+server {
+	location {
+		root /noidea;
+	}
+}

--- a/tests/config/test_configs/nginx.conf
+++ b/tests/config/test_configs/nginx.conf
@@ -4,12 +4,17 @@ autoindex on;
 index index.html;
 root    /var/www/;
 
+error_page 404 /404.html;
+error_page 500 502 503 504 /50x.html;
+
 server {
     listen       80;
     server_name  domain1.com www.domain1.com;
     index index.php index2.php;
+    error_page 404 /404_custom.html;
     location / {
         root   /var/www/;
+        error_page 42 /dontpanic.html;
     }
 }
 

--- a/tests/test_config.sh
+++ b/tests/test_config.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-clang++ ../src/config/*.cpp ./config/unit_tests.cpp ../src/get_next_line/*.cpp ../src/Utility.cpp -I ../inc/ -o config_test -Wall -Wextra -Werror && ./config_test
+clang++ ../src/config/*.cpp ./config/config_test_main.cpp ../src/get_next_line/*.cpp ../src/Utility.cpp -I ../inc/ -o config_test -Wall -Wextra -Werror && ./config_test
 rm config_test


### PR DESCRIPTION
Config now handles the `error_page` directive.

[Documentation on the directive](http://nginx.org/en/docs/http/ngx_http_core_module.html#error_page)

For example, this is how it will look in the config file (allowed on Config, VirtualHost, Location):
```
error_page 404             /404.html;
error_page 500 502 503 504 /50x.html;
```

The data is accessible with the following getter:

```
std::map<int, std::string> Config::getErrorPage(void) const;
```


i.e.:

`config/virtualHost/location.getErrorPage[404]` will return  `"/404.html"`
`config/virtualHost/location.getErrorPage[500]` will return  `"/50x.html"`


- Also, LimitExcept and Location now throw exceptions if they aren't completely formed (i.e. Location doesn't have a pattern).
- Added `ft_atoi` to `Utility.cpp`
