### PR TITLE
Ensure defaults comply with Nginx, facilitate integration testing

### DIFF
--- a/src/ServerTest.cpp
+++ b/src/ServerTest.cpp
@@ -19,17 +19,26 @@ void	shutdown(int signal)
 	exit(0);
 }
 
-int		main(void)
+int		main(int ac, char **av)
 {
 	size_t			i;
 	fd_set			fds;
 	int				new_socket;
 	Request			request;
-	ConfigReader	reader("./tests/config/test_configs/nginx.conf");
-	Config 			conf = reader.getConfig();
 	int 			sd;
 	int 			max_sd;
 	std::string 	final_path;
+	std::string path_to_conf("./tests/config/test_configs/nginx.conf");
+	
+	if (ac == 2)
+	{
+		path_to_conf = av[1];
+	}
+	std::cout << "Using config at " << path_to_conf << std::endl;
+	ConfigReader reader(path_to_conf);
+
+
+	Config conf = reader.getConfig();
 
 	s = Server();
 	s.setup();

--- a/src/config/ABlock.class.cpp
+++ b/src/config/ABlock.class.cpp
@@ -15,9 +15,10 @@
 
 ABlock::ABlock(ConfigFile &confFile) :
 	_confFile(confFile),
-	_clientMaxBodySize(0),
+	_clientMaxBodySize(1000000),
 	_autoindex(false),
-	_index(std::vector<std::string>())
+	_index(std::vector<std::string>(1, "index.html")),
+	_root("html")
 {
 }
 

--- a/src/config/Location.class.cpp
+++ b/src/config/Location.class.cpp
@@ -12,16 +12,24 @@
 
 #include "Location.class.hpp"
 
-Location::Location(ConfigFile &confFile) : ABlock(confFile), limitExcept(confFile)
+Location::Location(ConfigFile &confFile) :
+	ABlock(confFile),
+	limitExcept(confFile),
+	uploadStore(""),
+	rootSet(false),
+	fcgiSet(false),
+	uploadStoreSet(false)
 {
-	this->rootSet = false;
-	this->fcgiSet = false;
-	this->uploadStoreSet = false;
 }
 
-Location::Location(ABlock &ab) : ABlock(ab), limitExcept(ab.getConfFile())
+Location::Location(ABlock &ab) :
+	ABlock(ab),
+	limitExcept(ab.getConfFile()),
+	uploadStore(""),
+	rootSet(false),
+	fcgiSet(false),
+	uploadStoreSet(false)
 {
-
 }
 
 /*

--- a/src/config/VirtualHost.class.cpp
+++ b/src/config/VirtualHost.class.cpp
@@ -14,17 +14,17 @@
 
 VirtualHost::VirtualHost(ConfigFile &confFile) : 
 	ABlock(confFile),
-	serverName(1, ""),
+	listenIp(80),
 	listenHost("*"),
-	listenIp(80)
+	serverName(1, "")
 {
 }
 
 VirtualHost::VirtualHost(ABlock &ab) :
 	ABlock(ab),
-	serverName(1, ""),
+	listenIp(80),
 	listenHost("*"),
-	listenIp(80)
+	serverName(1, "")
 {
 }
 

--- a/src/config/VirtualHost.class.cpp
+++ b/src/config/VirtualHost.class.cpp
@@ -12,11 +12,19 @@
 
 #include "VirtualHost.class.hpp"
 
-VirtualHost::VirtualHost(ConfigFile &confFile) : ABlock(confFile)
+VirtualHost::VirtualHost(ConfigFile &confFile) : 
+	ABlock(confFile),
+	serverName(1, ""),
+	listenHost("*"),
+	listenIp(80)
 {
 }
 
-VirtualHost::VirtualHost(ABlock &ab) : ABlock(ab)
+VirtualHost::VirtualHost(ABlock &ab) :
+	ABlock(ab),
+	serverName(1, ""),
+	listenHost("*"),
+	listenIp(80)
 {
 }
 
@@ -56,15 +64,6 @@ void VirtualHost::handleLine(std::string lineString)
 	// }
 }
 
-// void VirtualHost::inheritParams(int _clientMaxBodySize, bool _autoindex,
-// 		std::string _root, std::vector<std::string> _index)
-// {
-// 	this->clientMaxBodySize = _clientMaxBodySize;
-// 	this->autoindex = _autoindex;
-// 	this->root = _root;
-// 	this->index = _index;
-// }
-
 int VirtualHost::getListenIp(void) const
 {
 	return this->listenIp;
@@ -85,34 +84,16 @@ std::vector<Location> VirtualHost::getLocations(void) const
 	return this->locations;
 }
 
-// int VirtualHost::getClientMaxBodySize(void) const
-// {
-// 	return this->clientMaxBodySize;
-// }
-
-// bool VirtualHost::getAutoindex(void) const
-// {
-// 	return this->autoindex;
-// }
-
-// std::vector<std::string> VirtualHost::getIndex(void) const
-// {
-// 	return this->index;
-// }
-
 std::string VirtualHost::getUploadStore(void) const
 {
 	return this->uploadStore;
 }
 
-// std::string VirtualHost::getRoot(void) const
-// {
-// 	return this->root;
-// }
-
 void VirtualHost::check(void)
 {
 	// specific checks
+	if (locations.size() == 0 && this->getRoot() == "" && this->getUploadStore() == "")
+		throw Exception("VirtualHost has to either have a location, or specify root or upload.");
 	for (size_t i = 0; i < locations.size(); i++)
 	{
 		locations[i].check();

--- a/tests/config/config_test_main.cpp
+++ b/tests/config/config_test_main.cpp
@@ -6,7 +6,7 @@
 /*   By: ashishae <ashishae@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/12/17 17:45:02 by ashishae          #+#    #+#             */
-/*   Updated: 2021/03/02 14:24:53 by ashishae         ###   ########.fr       */
+/*   Updated: 2021/03/03 12:14:08 by ashishae         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -212,8 +212,11 @@ int main(void)
 	out("Exception | location with empty or no pattern");
 	TEST_EXCEPTION(ConfigReader r3("./config/test_configs/location_without_pattern.conf"), Exception, "location has to have a pattern.");
 
-	out("Exception | location has to specify either root, fastcgi_pass or upload");
-	TEST_EXCEPTION(ConfigReader r3("./config/test_configs/location_without_action.conf"), Exception, "location has to specify either root, fastcgi_pass or upload.");
+	// out("Exception | location has to specify either root, fastcgi_pass or upload");
+	// TEST_EXCEPTION(ConfigReader r3("./config/test_configs/location_without_action.conf"), Exception, "location has to specify either root, fastcgi_pass or upload.");
+
+	// out("Exception | VirtualHost has to either have a location, or specify root or upload");
+	// TEST_EXCEPTION(ConfigReader r3("./config/test_configs/empty_virtualhost.conf"), Exception, "VirtualHost has to either have a location, or specify root or upload.");
 
 	out("Ft_split | empty string");
 	check(ft_split("", ' ').size() == 0);

--- a/tests/config/config_test_main.cpp
+++ b/tests/config/config_test_main.cpp
@@ -6,7 +6,7 @@
 /*   By: ashishae <ashishae@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/12/17 17:45:02 by ashishae          #+#    #+#             */
-/*   Updated: 2021/03/03 12:14:08 by ashishae         ###   ########.fr       */
+/*   Updated: 2021/03/03 12:35:49 by ashishae         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -212,11 +212,11 @@ int main(void)
 	out("Exception | location with empty or no pattern");
 	TEST_EXCEPTION(ConfigReader r3("./config/test_configs/location_without_pattern.conf"), Exception, "location has to have a pattern.");
 
-	// out("Exception | location has to specify either root, fastcgi_pass or upload");
-	// TEST_EXCEPTION(ConfigReader r3("./config/test_configs/location_without_action.conf"), Exception, "location has to specify either root, fastcgi_pass or upload.");
+	out("Exception | location has to specify either root, fastcgi_pass or upload");
+	TEST_EXCEPTION(ConfigReader r3("./config/test_configs/location_without_action.conf"), Exception, "location has to specify either root, fastcgi_pass or upload.");
 
-	// out("Exception | VirtualHost has to either have a location, or specify root or upload");
-	// TEST_EXCEPTION(ConfigReader r3("./config/test_configs/empty_virtualhost.conf"), Exception, "VirtualHost has to either have a location, or specify root or upload.");
+	out("Exception | VirtualHost has to either have a location, or specify root or upload");
+	TEST_EXCEPTION(ConfigReader r3("./config/test_configs/empty_virtualhost.conf"), Exception, "VirtualHost has to either have a location, or specify root or upload.");
 
 	out("Ft_split | empty string");
 	check(ft_split("", ' ').size() == 0);

--- a/tests/config/test_configs/empty_virtualhost.conf
+++ b/tests/config/test_configs/empty_virtualhost.conf
@@ -1,4 +1,6 @@
 server {
 	server_name whatever;
 	listen 80;
+	root ;
+	upload_store ;
 }

--- a/tests/config/test_configs/empty_virtualhost.conf
+++ b/tests/config/test_configs/empty_virtualhost.conf
@@ -1,0 +1,4 @@
+server {
+	server_name whatever;
+	listen 80;
+}

--- a/tests/config/test_configs/location_without_action.conf
+++ b/tests/config/test_configs/location_without_action.conf
@@ -1,4 +1,7 @@
 server {
 	location / {
+		root ;
+		fcgi_pass ;
+		upload_store ;
 	}
 }


### PR DESCRIPTION
This pull request brings a few unnoticeable changes to Config. Now Config objects all have Nginx-compliant default values for all attributes. You don't have to do anything for this to work, objects will just have the right values now.

Also, I've added an option to pass path to config to our executable through arguments, in case you need to test things with a specific config:

```
./webserv path_to_config 
```

If you don't specify this, the default test config is loaded instead.