### PR TITLE
Make CGIHandler constructible with Request and parameters

### DIFF
--- a/inc/CGIHandler.class.hpp
+++ b/inc/CGIHandler.class.hpp
@@ -37,9 +37,9 @@ typedef struct s_CGIRequest {
 	std::string remoteIdent;
 	std::string remoteUser;
 	std::string contentType;
-	// std::string pathInfo;
-	// std::string pathTranslated;
-	// std::string queryString;
+	std::string pathInfo;
+	std::string pathTranslated;
+	std::string queryString;
 	std::string requestMethod;
 	std::string requestURI;
 	std::string serverPort;

--- a/inc/CGIHandler.class.hpp
+++ b/inc/CGIHandler.class.hpp
@@ -22,7 +22,7 @@
 # include "get_next_line.h"
 # include "ICGIRequest.class.hpp"
 # include "Exception.class.hpp"
-
+# include "Request.class.hpp"
 
 # ifndef PHPCGI_PATH
 #  ifdef __APPLE__
@@ -65,6 +65,7 @@ public:
 	CGIHandler(std::string body, CGIRequest cr);
 
 	CGIHandler(ICGIRequest icr, CGIRequires cr);
+	CGIHandler(Request icr, CGIRequires cr);
 
 	// ~CGIHandler();
 	// CGIHandler(const CGIHandler &copy);
@@ -73,7 +74,7 @@ public:
 	std::string getCgiResponse(void) const;
 
 private:
-	std::string requestedFile;
+	// std::string requestedFile;
 	std::string cgiResponse;
 
 	CGIRequest _cgiRequest;
@@ -99,6 +100,11 @@ private:
 	void prepareEnvp(void);
 
 	void handleCgi(void);
+
+	void pipeline(std::string body);
+
+	// void parseRequest(ICGIRequest icr);
+	// void parseRequest(Request icr);
 };
 
 #endif

--- a/inc/CGIHandler.class.hpp
+++ b/inc/CGIHandler.class.hpp
@@ -32,7 +32,7 @@
 
 typedef struct s_CGIRequest {
 	std::string remoteAddr;
-	std::string remoteHost;
+	// std::string remoteHost;
 	std::string authType;
 	std::string remoteIdent;
 	std::string remoteUser;
@@ -48,13 +48,23 @@ typedef struct s_CGIRequest {
 	std::string pathToCGI;
 }	CGIRequest;
 
+typedef struct s_CGIRequires {
+	std::string scriptName;
+	std::string remoteAddr;
+	std::string requestURI; // ?????
+	std::string serverPort;
+	std::string serverName;
+	std::string pathToCGI;
+} CGIRequires;
+
 std::string		ft_itostr(int n);
 
 class CGIHandler {
 
 public:
 	CGIHandler(std::string body, CGIRequest cr);
-	// CGIHandler(ICGIRequest icr, std::string requestedFile);
+
+	CGIHandler(ICGIRequest icr, CGIRequires cr);
 
 	// ~CGIHandler();
 	// CGIHandler(const CGIHandler &copy);

--- a/inc/TestCGIRequest.class.hpp
+++ b/inc/TestCGIRequest.class.hpp
@@ -13,26 +13,29 @@
 #ifndef TESTCGIREQUEST_HPP
 # define TESTCGIREQUEST_HPP
 
-# include "ICGIRequest.class.hpp"
+// # include "ICGIRequest.class.hpp"
+#include "Request.class.hpp"
 
-class TestCGIRequest : public ICGIRequest {
+// A class that mocks the behavior of Request to test how its data
+// is processed by CGIHandler
+
+class TestCGIRequest : public Request {
 
 public:
 
 	TestCGIRequest(std::string method,
 	std::string body,
-	std::vector<Header *> headers,
-	std::string query,
-	std::string path,
-	std::string fragment);
+	std::vector<Header> headers,
+	// std::string query,
+	std::string path);
 	// ~TestCGIRequest();
 
 	std::string getMethod(void);
 	std::string getBody(void);
-	std::vector<Header *> getHeaders(void);
-	std::string getQuery(void);
+	std::vector<Header> getHeaders(void);
+	// std::string getQuery(void);
 	std::string getPath(void);
-	std::string getFragment(void);
+	// std::string getFragment(void);
 	// TestCGIRequest(const TestCGIRequest &copy);
 	// TestCGIRequest &operator= (const TestCGIRequest &operand);
 
@@ -40,10 +43,10 @@ private:
 
 	std::string _method;
 	std::string _body;
-	std::vector<Header *> _headers;
-	std::string _query;
+	std::vector<Header> _headers;
+	// std::string _query;
 	std::string _path;
-	std::string _fragment;
+	// std::string _fragment;
 
 
 

--- a/src/cgi/CGIHandler.class.cpp
+++ b/src/cgi/CGIHandler.class.cpp
@@ -147,7 +147,7 @@ void CGIHandler::prepareEnvp(void)
 		v.push_back("CONTENT_LENGTH=" + ft_itostr(bodySize));
 
 	v.push_back("REMOTE_ADDR=" + _cgiRequest.remoteAddr);
-	v.push_back("REMOTE_HOST=" + _cgiRequest.remoteHost);
+	// v.push_back("REMOTE_HOST=" + _cgiRequest.remoteHost);
 	v.push_back("REMOTE_IDENT=" + _cgiRequest.remoteIdent);
 	v.push_back("REMOTE_USER=" + _cgiRequest.remoteUser);
 	v.push_back("CONTENT_TYPE=" + _cgiRequest.contentType);
@@ -226,30 +226,44 @@ std::string getHeaderStringByKey(std::vector<Header *> hds, std::string key)
 // 	std::vector<std::string> words = split(authValue, ' ');
 // }
 
-// CGIHandler::CGIHandler(ICGIRequest icr, std::string _requestedFile)
-// {
-// 	requestedFile = _requestedFile;
-// 	_cgiRequest.scriptFilename = requestedFile;
-
-// 	std::vector<Header *> hds = icr.getHeaders();
-
-// 	// _cgiRequest.remoteAddr = ;
-// // 	_cgiRequest.remoteHost = ;
-// 	_cgiRequest.authType = getHeaderStringByKey(hds, "Authorization");
-// // 	_cgiRequest.remoteIdent = ;
-// // 	_cgiRequest.remoteUser = ;
-// // 	_cgiRequest.contentType = ;
-
-// // 	_cgiRequest.requestMethod = ;
-// // 	_cgiRequest.requestURI = ;
-// // 	_cgiRequest.serverPort = ;
-// // 	_cgiRequest.serverName = ;
-// // 	_cgiRequest.scriptFilename = ;
-// // 	_cgiRequest.pathToCGI = ;
 
 
+CGIHandler::CGIHandler(ICGIRequest icr, CGIRequires cr)
+{
+	// requestedFile = _requestedFile;
+	_cgiRequest.scriptFilename = requestedFile;
 
-// // }
+	std::vector<Header *> hds = icr.getHeaders();
+
+
+	// From Request headers
+	
+	// Auth
+	_cgiRequest.authType = getHeaderStringByKey(hds, "Authorization");
+// 	_cgiRequest.remoteIdent = ; // TODO
+// 	_cgiRequest.remoteUser = ; // TODO
+
+
+// 	_cgiRequest.contentType = ; // TODO
+
+// 	_cgiRequest.pathInfo = ;
+// 	_cgiRequest.pathTranslated = ;
+// 	_cgiRequest.queryString = ;
+
+	_cgiRequest.requestMethod = icr.getMethod();
+
+
+	// Passed as parameter from matching phase and request
+
+	// 	_cgiRequest.remoteHost = ; // not present in subject
+	_cgiRequest.remoteAddr = cr.remoteAddr;
+	_cgiRequest.requestURI = cr.requestURI;
+	_cgiRequest.serverPort = cr.serverPort;
+	_cgiRequest.serverName = cr.serverName;
+	_cgiRequest.scriptFilename = cr.scriptName;
+	_cgiRequest.pathToCGI = cr.pathToCGI;
+
+}
 
 CGIHandler::CGIHandler(std::string body, CGIRequest cr) :
 	requestedFile(cr.scriptFilename), _cgiRequest(cr)

--- a/src/cgi/CGIHandler.class.cpp
+++ b/src/cgi/CGIHandler.class.cpp
@@ -61,7 +61,6 @@ char	*ft_strdup(const char *s1)
 	return (p);
 }
 
-
 std::string		ft_itostr(int n)
 {
 	std::string		result;
@@ -81,15 +80,6 @@ std::string		ft_itostr(int n)
 		result.insert(0, "-");
 	return (result);
 }
-
-// TODO redo without free
-// std::string ft_itostr(int n)
-// {
-// 	char *s = ft_itoa(n);
-// 	std::string str(s);
-// 	free(s);
-// 	return str;
-// }
 
 char **create_envp(std::vector<std::string> mvars)
 {
@@ -227,19 +217,16 @@ std::string getHeaderStringByKey(std::vector<Header *> hds, std::string key)
 // }
 
 
-
-CGIHandler::CGIHandler(ICGIRequest icr, CGIRequires cr)
+CGIHandler::CGIHandler(Request icr, CGIRequires cr)
 {
-	// requestedFile = _requestedFile;
-	_cgiRequest.scriptFilename = requestedFile;
 
-	std::vector<Header *> hds = icr.getHeaders();
+	std::vector<Header> hds = icr.getHeaders();
 
 
 	// From Request headers
 	
 	// Auth
-	_cgiRequest.authType = getHeaderStringByKey(hds, "Authorization");
+	// _cgiRequest.authType = getHeaderStringByKey(hds, "Authorization");
 // 	_cgiRequest.remoteIdent = ; // TODO
 // 	_cgiRequest.remoteUser = ; // TODO
 
@@ -263,10 +250,18 @@ CGIHandler::CGIHandler(ICGIRequest icr, CGIRequires cr)
 	_cgiRequest.scriptFilename = cr.scriptName;
 	_cgiRequest.pathToCGI = cr.pathToCGI;
 
+	pipeline(icr.getBody());
 }
 
-CGIHandler::CGIHandler(std::string body, CGIRequest cr) :
-	requestedFile(cr.scriptFilename), _cgiRequest(cr)
+CGIHandler::CGIHandler(std::string body, CGIRequest cr) : _cgiRequest(cr)
+{
+	pipeline(body);
+}
+
+/*
+** Does all the internal work
+*/
+void CGIHandler::pipeline(std::string body)
 {
 	countBodySize(body);
 	openPipes();
@@ -276,7 +271,6 @@ CGIHandler::CGIHandler(std::string body, CGIRequest cr) :
 	close(pipe_out[1]);
 	readCgiResponse(pipe_out[0]);
 }
-
 
 
 void CGIHandler::countBodySize(std::string s)

--- a/src/cgi/CGIHandler.class.cpp
+++ b/src/cgi/CGIHandler.class.cpp
@@ -151,10 +151,10 @@ void CGIHandler::prepareEnvp(void)
 	v.push_back("REMOTE_IDENT=" + _cgiRequest.remoteIdent);
 	v.push_back("REMOTE_USER=" + _cgiRequest.remoteUser);
 	v.push_back("CONTENT_TYPE=" + _cgiRequest.contentType);
-	v.push_back("PATH_INFO=" + _cgiRequest.requestURI);
+	v.push_back("PATH_INFO=" + _cgiRequest.pathInfo);
 
-	v.push_back("PATH_TRANSLATED=");
-	v.push_back("QUERY_STRING=");
+	v.push_back("PATH_TRANSLATED=" + _cgiRequest.pathTranslated);
+	v.push_back("QUERY_STRING=" + _cgiRequest.queryString);
 
 	v.push_back("REQUEST_METHOD=" + _cgiRequest.requestMethod);
 	v.push_back("REQUEST_URI=" + _cgiRequest.requestURI);
@@ -178,19 +178,6 @@ void CGIHandler::prepareEnvp(void)
 
 	this->envp = create_envp(v);
 
-
-	// char **envp2 = envp;
-	// while (*envp2)
-	// {
-	// 	std::cout << *envp2 << std::endl;
-	// 	envp2++;
-	// }
-
-	// while (*envp)
-	// {
-	// 	// std::cout << "Envp: " << *envp << std::endl;
-	// 	// envp++;
-	// }
 }
 
 void CGIHandler::handleCgi(void)

--- a/src/cgi/TestCGIRequest.class.cpp
+++ b/src/cgi/TestCGIRequest.class.cpp
@@ -15,12 +15,11 @@
 TestCGIRequest::TestCGIRequest(
 	std::string method,
 	std::string body,
-	std::vector<Header *> headers,
-	std::string query,
-	std::string path,
-	std::string fragment) :
-	_method(method), _body(body), _headers(headers), _query(query),
-	_path(path), _fragment(fragment)
+	std::vector<Header> headers,
+	// std::string query,
+	std::string path) :
+	_method(method), _body(body), _headers(headers),
+	_path(path)
 {
 }
 
@@ -35,22 +34,22 @@ std::string TestCGIRequest::getBody(void)
 	return _body;
 }
 
-std::vector<Header *> TestCGIRequest::getHeaders(void)
+std::vector<Header> TestCGIRequest::getHeaders(void)
 {
 	return _headers;
 }
 
-std::string TestCGIRequest::getQuery(void)
-{
-	return _query;
-}
+// std::string TestCGIRequest::getQuery(void)
+// {
+// 	return _query;
+// }
 
 std::string TestCGIRequest::getPath(void)
 {
 	return _path;
 }
 
-std::string TestCGIRequest::getFragment(void)
-{
-	return _fragment;
-}
+// std::string TestCGIRequest::getFragment(void)
+// {
+// 	return _fragment;
+// }

--- a/tests/cgi/cgi_test_main.cpp
+++ b/tests/cgi/cgi_test_main.cpp
@@ -6,7 +6,7 @@
 /*   By: ashishae <ashishae@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/31 12:15:59 by ashishae          #+#    #+#             */
-/*   Updated: 2021/03/16 14:54:33 by ashishae         ###   ########.fr       */
+/*   Updated: 2021/03/16 15:04:34 by ashishae         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -229,9 +229,30 @@ int main(void)
 
 	// std::cout << "Lsls" << std::endl;
 	std::string resp3 = h3.getCgiResponse();
-	std::cout << resp3 << std::endl;
+	// std::cout << resp3 << std::endl;
 
 	envVarMap = responseToMap(resp3);
+
+	check(envVarMap["REMOTE_ADDR"] == "127.0.0.1"); 
+	// check(envVarMap["REMOTE_HOST"] == "testRemoteHost");
+	// check(envVarMap["REMOTE_IDENT"] == "testRemoteIdent");
+	// check(envVarMap["REMOTE_USER"] == "testRemoteUser");
+	// check(envVarMap["AUTH_TYPE"] == "testAuthType");
+	// check(envVarMap["CONTENT_TYPE"] == "testContentType");
+	// check(envVarMap["REQUEST_METHOD"] == "GET");
+	check(envVarMap["REQUEST_URI"] == "http://example.com/cgi/test.php");
+	check(envVarMap["SERVER_PORT"] == "80");
+	check(envVarMap["SERVER_NAME"] == "example.com");
+	check(envVarMap["SCRIPT_FILENAME"] != "");
+	check(envVarMap["SCRIPT_FILENAME"].find("test-cgi.php") != std::string::npos);
+	
+	check(envVarMap["SCRIPT_NAME"].find("test-cgi.php") != std::string::npos);
+	
+	// check(envVarMap["PATH_INFO"] == "examplePathInfo"); 
+	
+	check(envVarMap["GATEWAY_INTERFACE"] == "CGI/1.1");
+	check(envVarMap["SERVER_PROTOCOL"] == "HTTP/1.1");
+	check(envVarMap["SERVER_SOFTWARE"] == "Webserv/1.1");
 
 	// std::cout <<  << std::endl;
 

--- a/tests/cgi/cgi_test_main.cpp
+++ b/tests/cgi/cgi_test_main.cpp
@@ -6,7 +6,7 @@
 /*   By: ashishae <ashishae@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/31 12:15:59 by ashishae          #+#    #+#             */
-/*   Updated: 2021/03/05 14:55:56 by ashishae         ###   ########.fr       */
+/*   Updated: 2021/03/16 12:49:03 by ashishae         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -59,6 +59,9 @@ std::string testBodyWrite(std::string stringToWrite,
 		"testRemoteIdent", // remoteIdent
 		"testRemoteUser", // remoteUser
 		"testContentType", // contentType
+		"examplePathInfo", // pathInfo,
+		"examplePathTranslated", // pathTranslated,
+		"exampleQueryString", // queryString
 		"GET", // requestMethod
 		"http://example.com/cgi/test.php", // requestURI
 		"80", // serverPort
@@ -99,6 +102,8 @@ int main(void)
 	else
 		path_to_pcgi = "/usr/local/bin/php-cgi";
 
+	std::cout << "Calculated php-cgi to be at: " << path_to_pcgi << std::endl;
+
 	out("CGI Variables test");
 
 	CGIRequest cr2 = {
@@ -107,7 +112,10 @@ int main(void)
 		"testAuthType", // authType
 		"testRemoteIdent", // remoteIdent
 		"testRemoteUser", // remoteUser
-		"testContentType", // contentType
+		"testContentType", // contentType,
+		"examplePathInfo", // pathInfo,
+		"examplePathTranslated", // pathTranslated,
+		"exampleQueryString", // queryString
 		"GET", // requestMethod
 		"http://example.com/cgi/test.php", // requestURI
 		"80", // serverPort
@@ -135,7 +143,8 @@ int main(void)
 	check(envVarMap["SCRIPT_FILENAME"] != "");
 	check(envVarMap["SCRIPT_FILENAME"].find("test-cgi.php") != std::string::npos);
 	check(envVarMap["SCRIPT_NAME"].find("test-cgi.php") != std::string::npos);
-	check(envVarMap["PATH_INFO"] == "http://example.com/cgi/test.php");
+	std::cout << "Here" << std::endl;
+	check(envVarMap["PATH_INFO"] == "examplePathiInfo");
 	check(envVarMap["GATEWAY_INTERFACE"] == "CGI/1.1");
 	check(envVarMap["SERVER_PROTOCOL"] == "HTTP/1.1");
 	check(envVarMap["SERVER_SOFTWARE"] == "Webserv/1.1");
@@ -168,8 +177,6 @@ int main(void)
 	check(testBodyWrite("testBody", s_pwd, path_to_pcgi) == "testBody\n");
 	check(testBodyWrite("testBody\nlol", s_pwd, path_to_pcgi) == "testBody\nlol\n");
 	check(testBodyWrite("testBody\nlol\nonemoreline", s_pwd, path_to_pcgi) == "testBody\nlol\nonemoreline\n");
-
-
 
 
 	out("TestCGIRequest | Constructor");

--- a/tests/cgi/cgi_test_main.cpp
+++ b/tests/cgi/cgi_test_main.cpp
@@ -6,7 +6,7 @@
 /*   By: ashishae <ashishae@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/31 12:15:59 by ashishae          #+#    #+#             */
-/*   Updated: 2021/03/16 12:49:03 by ashishae         ###   ########.fr       */
+/*   Updated: 2021/03/16 13:30:37 by ashishae         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -54,7 +54,7 @@ std::string testBodyWrite(std::string stringToWrite,
 {
 	CGIRequest cr3 = {
 		"127.0.0.1", // remoteAddr
-		"testRemoteHost", // remoteHost
+		// "testRemoteHost", // remoteHost
 		"testAuthType", // authType
 		"testRemoteIdent", // remoteIdent
 		"testRemoteUser", // remoteUser
@@ -108,7 +108,7 @@ int main(void)
 
 	CGIRequest cr2 = {
 		"127.0.0.1", // remoteAddr
-		"testRemoteHost", // remoteHost
+		// "testRemoteHost", // remoteHost
 		"testAuthType", // authType
 		"testRemoteIdent", // remoteIdent
 		"testRemoteUser", // remoteUser
@@ -130,8 +130,8 @@ int main(void)
 
 	std::map<std::string, std::string> envVarMap = responseToMap(resp2);
 
-	check(envVarMap["REMOTE_ADDR"] == "127.0.0.1");
-	check(envVarMap["REMOTE_HOST"] == "testRemoteHost");
+	check(envVarMap["REMOTE_ADDR"] == "127.0.0.1"); 
+	// check(envVarMap["REMOTE_HOST"] == "testRemoteHost");
 	check(envVarMap["REMOTE_IDENT"] == "testRemoteIdent");
 	check(envVarMap["REMOTE_USER"] == "testRemoteUser");
 	check(envVarMap["AUTH_TYPE"] == "testAuthType");
@@ -143,8 +143,7 @@ int main(void)
 	check(envVarMap["SCRIPT_FILENAME"] != "");
 	check(envVarMap["SCRIPT_FILENAME"].find("test-cgi.php") != std::string::npos);
 	check(envVarMap["SCRIPT_NAME"].find("test-cgi.php") != std::string::npos);
-	std::cout << "Here" << std::endl;
-	check(envVarMap["PATH_INFO"] == "examplePathiInfo");
+	check(envVarMap["PATH_INFO"] == "examplePathInfo");
 	check(envVarMap["GATEWAY_INTERFACE"] == "CGI/1.1");
 	check(envVarMap["SERVER_PROTOCOL"] == "HTTP/1.1");
 	check(envVarMap["SERVER_SOFTWARE"] == "Webserv/1.1");
@@ -212,5 +211,6 @@ int main(void)
 	check(tcr.getPath() == "testPath");
 	check(tcr.getFragment() == "testFragment");
 
+	test_results();
 
 }

--- a/tests/cgi/cgi_test_main.cpp
+++ b/tests/cgi/cgi_test_main.cpp
@@ -6,7 +6,7 @@
 /*   By: ashishae <ashishae@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/31 12:15:59 by ashishae          #+#    #+#             */
-/*   Updated: 2021/03/16 13:30:37 by ashishae         ###   ########.fr       */
+/*   Updated: 2021/03/16 14:54:33 by ashishae         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -180,36 +180,60 @@ int main(void)
 
 	out("TestCGIRequest | Constructor");
 
-	std::vector<Header *> hds;
+	std::vector<Header> hds;
 
 	std::vector<std::string> values;
 	values.push_back("testValue1");
 	values.push_back("testValue2");
 
-	Header *header = new Header("testKey", values);
+	Header header = Header("testKey", values);
 
 	hds.push_back(header);
 
 	TestCGIRequest tcr("GET",
 		"testBody",
 		hds,
-		"testQuery",
-		"testPath",
-		"testFragment"
+		// "testQuery",
+		"testPath"
+		// "testFragment"
 	);
 
 	check(tcr.getMethod() == "GET");
 	check(tcr.getBody() == "testBody");
 
 	check(tcr.getHeaders().size() == 1);
-	check(tcr.getHeaders()[0]->getName() == "testKey");
-	check(tcr.getHeaders()[0]->getValue().size() == 2);
-	check(tcr.getHeaders()[0]->getValue()[0] == "testValue1");
-	check(tcr.getHeaders()[0]->getValue()[1] == "testValue2");
+	check(tcr.getHeaders()[0].getName() == "testKey");
+	check(tcr.getHeaders()[0].getValue().size() == 2);
+	check(tcr.getHeaders()[0].getValue()[0] == "testValue1");
+	check(tcr.getHeaders()[0].getValue()[1] == "testValue2");
 
-	check(tcr.getQuery() == "testQuery");
+	// check(tcr.getQuery() == "testQuery");
 	check(tcr.getPath() == "testPath");
-	check(tcr.getFragment() == "testFragment");
+	// check(tcr.getFragment() == "testFragment");
+
+	out("CGIHandler from Request and a few params");
+
+	CGIRequires crs = {
+		s_pwd + "/cgi/test-cgi.php", // scriptFilename
+		"127.0.0.1", // remoteAddr
+		"http://example.com/cgi/test.php", // requestURI
+		"80", // serverPort
+		"example.com", // serverName
+		path_to_pcgi // pathToCGI
+	};
+
+
+
+	CGIHandler h3(tcr, crs);
+
+
+	// std::cout << "Lsls" << std::endl;
+	std::string resp3 = h3.getCgiResponse();
+	std::cout << resp3 << std::endl;
+
+	envVarMap = responseToMap(resp3);
+
+	// std::cout <<  << std::endl;
 
 	test_results();
 

--- a/tests/cgi/test-cgi.php
+++ b/tests/cgi/test-cgi.php
@@ -1,6 +1,6 @@
 <?php
 echo "REMOTE_ADDR: " . $_SERVER['REMOTE_ADDR'] . "\n";
-echo "REMOTE_HOST: " . $_SERVER['REMOTE_HOST'] . "\n";
+// echo "REMOTE_HOST: " . $_SERVER['REMOTE_HOST'] . "\n";
 echo "REMOTE_IDENT: " . $_SERVER['REMOTE_IDENT'] . "\n";
 echo "REMOTE_USER: " . $_SERVER['REMOTE_USER'] . "\n";
 echo "AUTH_TYPE: " . $_SERVER['AUTH_TYPE'] . "\n";


### PR DESCRIPTION
This PR introduces a new constructor to CGIHandler:

```
CGIHandler::CGIHandler(Request r, CGIRequires cr);
```

It allows us to launch CGI by passing it the incoming request and a structure with other parameters (those that depend on Config and server's internals).

The parameter structure is defined as follows:

```
typedef struct s_CGIRequires {
	std::string scriptName; // this is the path to the php file to be launched 
	std::string remoteAddr; // the IP of the client
	std::string requestURI; // present in 42 subject, doesn't exist in RFC. I suspect it's just the full path of the request
	std::string serverPort; // the port which received the request
	std::string serverName; // the name of the server that received the request
	std::string pathToCGI; // the path to the CGI interpreter (i.e. php-cgi)
} CGIRequires;
```

These parameters are then given to CGI as meta-variables (except pathToCGI). You can find a more detailed description of every parameter in this rfc: https://tools.ietf.org/html/rfc3875
