### PR TITLE
Parse Authorization and Content-Type in CGIHandler

### DIFF
--- a/inc/Base64.class.hpp
+++ b/inc/Base64.class.hpp
@@ -1,0 +1,41 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   Base64.class.hpp                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ashishae <ashishae@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2021/01/30 20:21:51 by ashishae          #+#    #+#             */
+/*   Updated: 2021/02/07 15:10:56 by ashishae         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef BASE64_CLASS_HPP
+# define BASE64_CLASS_HPP
+
+# include <unistd.h>
+# include <vector>
+# include <string>
+
+
+# include "Exception.class.hpp"
+
+# include "Utility.hpp"
+
+
+class Base64 {
+
+public:
+	Base64(std::string input);
+
+	// ~Base64();
+	// Base64(const Base64 &copy);
+	// Base64 &operator= (const Base64 &operand);
+	std::string decode(void);
+
+
+private:
+	std::string _content;
+};
+
+#endif

--- a/inc/CGIHandler.class.hpp
+++ b/inc/CGIHandler.class.hpp
@@ -23,6 +23,8 @@
 # include "ICGIRequest.class.hpp"
 # include "Exception.class.hpp"
 # include "Request.class.hpp"
+# include "Utility.hpp"
+# include "Base64.class.hpp"
 
 # ifndef PHPCGI_PATH
 #  ifdef __APPLE__
@@ -55,7 +57,13 @@ typedef struct s_CGIRequires {
 	std::string serverPort;
 	std::string serverName;
 	std::string pathToCGI;
-} CGIRequires;
+}	CGIRequires;
+
+typedef struct s_authResult {
+	std::string authType;
+	std::string user;
+	std::string password;
+}	authResult;
 
 std::string		ft_itostr(int n);
 
@@ -72,6 +80,8 @@ public:
 	// CGIHandler &operator= (const CGIHandler &operand);
 
 	std::string getCgiResponse(void) const;
+
+	static authResult parseAuth(std::string authHeader);
 
 private:
 	// std::string requestedFile;

--- a/src/Base64.class.cpp
+++ b/src/Base64.class.cpp
@@ -1,0 +1,65 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   Base64.class.hpp                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ashishae <ashishae@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2021/01/30 20:21:51 by ashishae          #+#    #+#             */
+/*   Updated: 2021/02/07 15:10:56 by ashishae         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "Base64.class.hpp"
+
+const std::string sequence = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+Base64::Base64(std::string input) :
+	_content(input)
+{
+}
+
+unsigned char lookup(char c)
+{
+	unsigned char i = 0;
+	while (i < sequence.size())
+	{
+		if (sequence.at(i) == c)
+			return i;
+		i++;
+	}
+	throw Exception("Wrong characters in Base64.");
+}
+
+std::string Base64::decode(void)
+{
+	std::string ret;
+
+	unsigned char* p = (unsigned char*)_content.c_str();
+
+	size_t len = _content.size();
+
+	int pad = len > 0 && (len % 4 || p[len - 1] == '=');
+	const size_t L = ((len + 3) / 4 - pad) * 4;
+
+	for (size_t i = 0; i < L; i += 4)
+	{
+		int n = lookup(p[i]) << 18 | lookup(p[i + 1]) << 12 | lookup(p[i + 2]) << 6 | lookup(p[i + 3]);
+		ret.push_back((char)(n >> 16));
+		ret.push_back((char)(n >> 8 & 0xFF));
+		ret.push_back((char)(n & 0xFF));
+	}
+	if (pad)
+	{
+		int n = lookup(p[L]) << 18 | lookup(p[L + 1]) << 12;
+		ret.push_back(n >> 16);
+
+		if (len > L + 2 && p[L + 2] != '=')
+		{
+			n |= lookup(p[L + 2]) << 6;
+			ret.push_back(n >> 8 & 0xFF);
+		}
+	}
+
+	return ret;
+}

--- a/src/cgi/TestCGIRequest.class.cpp
+++ b/src/cgi/TestCGIRequest.class.cpp
@@ -21,6 +21,21 @@ TestCGIRequest::TestCGIRequest(
 	_method(method), _body(body), _headers(headers),
 	_path(path)
 {
+	std::string longValue;
+	std::vector<std::string> valueVector;
+	std::string finalString;
+
+	for (size_t i = 0; i < headers.size(); ++i)
+	{
+		valueVector = headers[i].getValue();
+		longValue = "";
+		for (size_t j = 0; j < valueVector.size(); j++)
+			longValue += valueVector[j];
+
+		Request::addHeader(headers[i].getName() + ": " + longValue + "\n");
+		/* code */
+	}
+	// std::cout << "Constructor got: " << headers.size() << std::endl;
 }
 
 

--- a/tests/cgi/cgi_test_main.cpp
+++ b/tests/cgi/cgi_test_main.cpp
@@ -6,7 +6,7 @@
 /*   By: ashishae <ashishae@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/31 12:15:59 by ashishae          #+#    #+#             */
-/*   Updated: 2021/03/16 15:04:34 by ashishae         ###   ########.fr       */
+/*   Updated: 2021/03/17 18:47:19 by ashishae         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,7 +16,20 @@
 #include <cstdlib>
 #include <map>
 #include "Utility.hpp"
+#include "Base64.class.hpp"
 
+
+std::string flatten(std::vector<std::string> v)
+{
+	std::string ret = "";
+
+	for (size_t i = 0; i < v.size(); i++)
+	{
+		ret += v[i] + ' ';
+	}
+
+	return ret;
+}
 
 // Turn CGI reponse containing key:value pairs into a map for testing
 std::map<std::string, std::string> responseToMap(std::string cgi_response)
@@ -34,12 +47,25 @@ std::map<std::string, std::string> responseToMap(std::string cgi_response)
 	std::vector<std::string> l;
 	while (j != lines.size())
 	{
+		// std::cout << "L: " << lines[j] << std::endl;
 		l = ft_split(lines[j], ' ');
 		if (l.size() == 2)
 		{
 			key = l[0];
 			value = l[1];
 			key.erase(key.size()-1, 1);
+
+			// std::cout << "K: " << key << ", V: " << value << std::endl;
+			envVarMap[key] = value;
+		}
+		else if (l.size() > 2)
+		{
+			key = l[0];
+			key.erase(key.size()-1, 1);
+			l.erase(l.begin());
+
+			std::string value = flatten(l);
+			value.erase(value.size()-1, 1);
 			envVarMap[key] = value;
 		}
 		j++;
@@ -94,10 +120,16 @@ int main(void)
 
 	const char *logname = std::getenv("LOGNAME");
 
+	const char *phpcgienv = std::getenv("PHPCGI");
+
+	std::cout << logname << std::endl;
+
 	std::string path_to_pcgi;
 
+	if (phpcgienv != NULL)
+		path_to_pcgi = phpcgienv;
 	// If we're at campus, php-cgi will be installed at brew
-	if (logname != NULL)
+	else if (logname != NULL)
 		path_to_pcgi = "/Users/" + std::string(logname) + "/.brew/bin/php-cgi";
 	else
 		path_to_pcgi = "/usr/local/bin/php-cgi";
@@ -190,6 +222,18 @@ int main(void)
 
 	hds.push_back(header);
 
+	values.clear();
+
+	values.push_back("Basic YWxhZGRpbjpvcGVuc2VzYW1l");
+
+	hds.push_back(Header("Authorization", values));
+
+	values.clear();
+
+	values.push_back("text/html; charset=UTF-8");
+
+	hds.push_back(Header("Content-Type", values));
+
 	TestCGIRequest tcr("GET",
 		"testBody",
 		hds,
@@ -201,7 +245,7 @@ int main(void)
 	check(tcr.getMethod() == "GET");
 	check(tcr.getBody() == "testBody");
 
-	check(tcr.getHeaders().size() == 1);
+	check(tcr.getHeaders().size() == 3);
 	check(tcr.getHeaders()[0].getName() == "testKey");
 	check(tcr.getHeaders()[0].getValue().size() == 2);
 	check(tcr.getHeaders()[0].getValue()[0] == "testValue1");
@@ -229,16 +273,18 @@ int main(void)
 
 	// std::cout << "Lsls" << std::endl;
 	std::string resp3 = h3.getCgiResponse();
-	// std::cout << resp3 << std::endl;
+	std::cout << resp3 << std::endl;
 
 	envVarMap = responseToMap(resp3);
 
 	check(envVarMap["REMOTE_ADDR"] == "127.0.0.1"); 
-	// check(envVarMap["REMOTE_HOST"] == "testRemoteHost");
-	// check(envVarMap["REMOTE_IDENT"] == "testRemoteIdent");
-	// check(envVarMap["REMOTE_USER"] == "testRemoteUser");
-	// check(envVarMap["AUTH_TYPE"] == "testAuthType");
-	// check(envVarMap["CONTENT_TYPE"] == "testContentType");
+	// check(envVarMap["REMOTE_HOST"] == "testRemoteHost"); // not present in subject
+	check(envVarMap["REMOTE_IDENT"] == "opensesame");
+	check(envVarMap["REMOTE_USER"] == "aladdin");
+	check(envVarMap["AUTH_TYPE"] == "Basic");
+	std::cout << "Here" << std::endl;
+	std::cout << envVarMap["CONTENT_TYPE"] << std::endl;
+	check(envVarMap["CONTENT_TYPE"] == "text/html; charset=UTF-8");
 	// check(envVarMap["REQUEST_METHOD"] == "GET");
 	check(envVarMap["REQUEST_URI"] == "http://example.com/cgi/test.php");
 	check(envVarMap["SERVER_PORT"] == "80");
@@ -255,6 +301,18 @@ int main(void)
 	check(envVarMap["SERVER_SOFTWARE"] == "Webserv/1.1");
 
 	// std::cout <<  << std::endl;
+
+	out("Base64 decoding");
+	Base64 b("QUJD");
+	check(b.decode() == "ABC");
+
+	out("Authorization header parsing");
+
+	authResult res = CGIHandler::parseAuth("Basic YWxhZGRpbjpvcGVuc2VzYW1l");
+
+	check(res.authType == "Basic");
+	check(res.user == "aladdin");
+	check(res.password == "opensesame");
 
 	test_results();
 

--- a/tests/test_cgi.sh
+++ b/tests/test_cgi.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-clang++ ../src/cgi/*.cpp ../src/Header.class.cpp ../src/Request.class.cpp ../src/config/Exception.class.cpp ../src/get_next_line/*.cpp ./cgi/cgi_test_main.cpp ../src/Utility.cpp -fsanitize=address -I ../inc/ -o cgi_test
+clang++ ../src/cgi/*.cpp ../src/Header.class.cpp ../src/Request.class.cpp ../src/config/Exception.class.cpp ../src/get_next_line/*.cpp ./cgi/cgi_test_main.cpp ../src/Utility.cpp ../src/Base64.class.cpp -fsanitize=address -I ../inc/ -o cgi_test
 ./cgi_test ; rm ./cgi_test


### PR DESCRIPTION
Now CGIHandler correctly handles the Authorization header, decoding the Base64-encoded credentials, and handles the Content-Type header to pass them to CGI meta-variables