### PR TITLE
Clean Config, move to listenPort from listenIp

### DIFF
--- a/inc/ABlock.class.hpp
+++ b/inc/ABlock.class.hpp
@@ -59,7 +59,7 @@ public:
 			std::map<std::string, std::string> &params);
 	static bool parseBoolDirective(std::string lineString, std::string key);
 	static void parseListen(std::string lineString, std::string &listenHost,
-							int &listenIp);
+							int &listenPort);
 
 	static int countOccurence(std::string s, char c);
 

--- a/inc/Base64.class.hpp
+++ b/inc/Base64.class.hpp
@@ -17,22 +17,18 @@
 # include <vector>
 # include <string>
 
-
 # include "Exception.class.hpp"
 
 # include "Utility.hpp"
 
-
+/*
+** The class that handles Base64 decoding.
+*/
 class Base64 {
 
 public:
 	Base64(std::string input);
-
-	// ~Base64();
-	// Base64(const Base64 &copy);
-	// Base64 &operator= (const Base64 &operand);
 	std::string decode(void);
-
 
 private:
 	std::string _content;

--- a/inc/Config.class.hpp
+++ b/inc/Config.class.hpp
@@ -16,27 +16,21 @@
 # include "ABlock.class.hpp"
 # include "VirtualHost.class.hpp"
 
+/*
+** Config represents the entire file, and roughly corresponds to the 
+** http context in NGINX.
+*/
 class Config : public ABlock
 {
 public:
 	Config(ConfigFile &confFile);
 	virtual void handleLine(std::string lineString);
 	void handle();
-
 	std::vector<VirtualHost> getVirtualHostVector(void) const;
-	// int getClientMaxBodySize(void) const;
-	// bool getAutoindex(void) const;
-	// std::vector<std::string> getIndex(void) const;
-	// std::string getRoot(void) const;
-
 	void check(void);
 
 private:
 	std::vector<VirtualHost> virtualHostVector;
-	// int clientMaxBodySize;
-	// bool autoindex;
-	// std::vector<std::string> index;
-	// std::string root;
 
 };
 

--- a/inc/ConfigFile.class.hpp
+++ b/inc/ConfigFile.class.hpp
@@ -18,15 +18,22 @@
 # include <fcntl.h>
 # include "get_next_line.h"
 
+/*
+** An abstraction for reading config files in a while loop, raising file
+** exception errors, and closing the file.
+*/
 class ConfigFile
 {
 public:
+	// Default constructor for ConfigFile. Use openFile then to open a file.
 	ConfigFile();
+
+	// Use this constructor normally.
 	ConfigFile(std::string filename);
+
 
 	void openFile(std::string filename);
 
-	// void next();
 	int getNext();
 	std::string getLineString(void) const;
 	void rewind(void);

--- a/inc/ConfigReader.class.hpp
+++ b/inc/ConfigReader.class.hpp
@@ -15,22 +15,12 @@
 
 # include <string>
 # include <vector>
-# include <map>
-
-# include <fcntl.h>
-# include <sys/types.h>
-# include <sys/uio.h>
-# include <unistd.h>
-# include <iostream>
-# include <algorithm>
-
 
 # include "get_next_line.h"
 # include "Exception.class.hpp"
 
 # include "ConfigFile.class.hpp"
 # include "Config.class.hpp"
-// # include "ABlock.class.hpp"
 # include "VirtualHost.class.hpp"
 
 class ConfigReader
@@ -38,24 +28,13 @@ class ConfigReader
 public:
 	ConfigReader(std::string filename);
 
-	Config *createConfig();
 	Config getConfig(void) const;
 
 private:
-	// int fd;
-	// int ret;
-	// char *line;
-
 	ConfigFile confFile;
-
-	Config *configBlock;
 	Config _config;
 	std::string lineString;
 
-	// virtualHostPrototype vhp;
-	// locationPrototype lp;
-	// configPrototype cp;
-	// limitExceptPrototype lep;
 	std::string lastLineParsed;
 
 	void parse();

--- a/inc/Exception.class.hpp
+++ b/inc/Exception.class.hpp
@@ -15,10 +15,13 @@
 
 # include <string>
 
+/*
+** The class that implements exception (42 subject doesn't allow to use
+** the exception header).
+*/
 class Exception {
 
 public:
-
 	Exception(std::string message);
 	~Exception();
 	Exception(const Exception &copy);

--- a/inc/LimitExcept.class.hpp
+++ b/inc/LimitExcept.class.hpp
@@ -14,14 +14,16 @@
 # define LIMITEXCEPT_CLASS_HPP
 
 # include "ABlock.class.hpp"
-// # include "LocationBlock.class.hpp"
 # include "Utility.hpp"
 
+/*
+** The block that represents the limit_except directive.
+*/
 class LimitExcept : public ABlock
 {
 public:
 	LimitExcept(ConfigFile &confFile);
-	virtual void handleLine(std::string lineString);
+	void handleLine(std::string lineString);
 
 	static std::vector<std::string> parseMethods(std::string line);
 	
@@ -38,7 +40,6 @@ private:
 	std::vector<std::string> _methods;
 
 	bool _empty;
-
 };
 
 #endif

--- a/inc/Location.class.hpp
+++ b/inc/Location.class.hpp
@@ -21,32 +21,22 @@
 # include "Utility.hpp"
 # include "LimitExcept.class.hpp"
 
+/*
+** The class that represents a location context in a NGINX config file.
+*/
 class Location : public ABlock
 {
 public:
 	Location(ConfigFile &confFile);
-
 	Location(ABlock &ab);
+
 	void handleLine(std::string lineString);
 
-	// void inheritParams(int clientMaxBodySize, bool autoindex, std::string root,
-	// 		std::vector<std::string> index, std::string uploadStore);
-
-	// void inheritParams(ABlock *parent);
-
 	std::string getPattern(void) const;
-	// std::string getRoot(void) const;
-	// int getClientMaxBodySize(void) const;
-	// bool getAutoindex(void) const;
-	// std::vector<std::string> getIndex(void) const;
-	// LimitExcept getLimitExcept(void) const;
-
-
 	std::string getFcgiPass(void) const;
 	std::map<std::string, std::string> getFcgiParams(void) const;
 	std::string getUploadStore(void) const;
 	LimitExcept getLimitExcept(void) const;
-
 	bool getFcgiSet(void) const;
 	bool getRootSet(void) const;
 	bool getUploadStoreSet(void) const;
@@ -56,14 +46,8 @@ public:
 	void check(void);
 
 private:
-
 	std::string parsePattern(std::string line);
-
 	std::string pattern;
-	
-	// std::vector<std::string> index;
-	// LimitExcept limitExcept;
-
 	LimitExcept limitExcept;
 	std::string fcgiPass;
 	std::map<std::string, std::string> fcgiParams;

--- a/inc/VirtualHost.class.hpp
+++ b/inc/VirtualHost.class.hpp
@@ -16,6 +16,11 @@
 # include "ABlock.class.hpp"
 # include "Location.class.hpp"
 
+/*
+** The VirtualHost class represents a server-block in an NGINX config file.
+** The name, ironically, comes from Apache. But we already had a Server
+** class at that moment.
+*/
 class VirtualHost : public ABlock
 {
 public:
@@ -25,30 +30,21 @@ public:
 	void handleLine(std::string lineString);
 
 	int getListenIp(void) const;
+	int getListenPort(void) const;
 	std::string getListenHost(void) const;
 	std::vector<std::string> getServerName(void) const;
 	std::vector<Location> getLocations(void) const;
-	// int getClientMaxBodySize(void) const;
-	// bool getAutoindex(void) const;
-	// std::vector<std::string> getIndex(void) const;
 	std::string getUploadStore(void) const;
-	// std::string getRoot(void) const;
-
-	// void inheritParams(int clientMaxBodySize, bool autoindex, std::string root,
-			// std::vector<std::string> index);
 
 	void check(void);
 
 private:
-	std::vector<Location> locationBlockVector;
 
-	int listenIp;
-	std::string listenHost;
-	std::vector<std::string> serverName;
-	std::vector<Location> locations;
-	std::string uploadStore;
-	// std::string root;
-
+	int _listenPort;
+	std::string _listenHost;
+	std::vector<std::string> _serverName;
+	std::vector<Location> _locations;
+	std::string _uploadStore;
 };
 
 #endif

--- a/src/Base64.class.cpp
+++ b/src/Base64.class.cpp
@@ -14,11 +14,19 @@
 
 const std::string sequence = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
+/*
+** Constructor for Base64.
+*/
 Base64::Base64(std::string input) :
 	_content(input)
 {
 }
 
+/*
+** Return the position of c in the Base64 sequence.
+** @param c the character to look up.
+** @ret unsigned char The position of c in the Base64 sequence.
+*/
 unsigned char lookup(char c)
 {
 	unsigned char i = 0;
@@ -31,6 +39,10 @@ unsigned char lookup(char c)
 	throw Exception("Wrong characters in Base64.");
 }
 
+/*
+** Decode the _content from Base64 and return it as a string.
+** @ret string The resulting string.
+*/
 std::string Base64::decode(void)
 {
 	std::string ret;

--- a/src/config/ABlock.class.cpp
+++ b/src/config/ABlock.class.cpp
@@ -314,11 +314,11 @@ bool ABlock::parseBoolDirective(std::string lineString, std::string key)
 ** @param lineString The line belonging to this block
 ** @param listenHost The reference to the listenHost variable that will be set
 ** to the actual listen host.
-** @param listenIp The reference to the listenIp variable, that will be set to
-** the port.
+** @param listenPort The reference to the listenPort variable, that will be set 
+** to the port.
 */
 void ABlock::parseListen(std::string lineString, std::string &listenHost,
-							int &listenIp)
+							int &listenPort)
 {
 	std::string directive = getStringDirective(lineString, "listen");
 	size_t valueStart = 0;
@@ -328,13 +328,13 @@ void ABlock::parseListen(std::string lineString, std::string &listenHost,
 		listenHost = directive.substr(valueStart, hostEnd - valueStart);
 		trimWhitespaceStart(listenHost);
 		size_t valueEnd = directive.find(";", hostEnd);
-		listenIp = ft_atoi(
+		listenPort = ft_atoi(
 			directive.substr(hostEnd+1, valueEnd - hostEnd).c_str());
 	}
 	else
 	{
 		listenHost = "";
-		listenIp = ft_atoi(directive.c_str());
+		listenPort = ft_atoi(directive.c_str());
 	}
 }
 

--- a/src/config/Config.class.cpp
+++ b/src/config/Config.class.cpp
@@ -12,6 +12,9 @@
 
 #include "Config.class.hpp"
 
+/*
+** Config constructor.
+*/
 Config::Config(ConfigFile &confFile) : ABlock(confFile)
 {
 }
@@ -21,7 +24,6 @@ Config::Config(ConfigFile &confFile) : ABlock(confFile)
 ** in braces), so we don't need a break condition. We also don't need
 ** to check if the block was closed.
 */
-
 void Config::handle()
 {
 	do
@@ -36,10 +38,16 @@ void Config::handle()
 	Config::check();
 }
 
+/*
+** Return true, if two VirtualHosts have common serverNames.
+** @param vh1 First VH.
+** @param vh2 Second VH.
+** @ret bool Do the VH have at least one common serverName.
+*/
 bool duplicatesInServerName(VirtualHost vh1, VirtualHost vh2)
 {
-	std::vector<std::string> v1 = vh1.getServerName();
-	std::vector<std::string> v2 = vh2.getServerName();
+	const std::vector<std::string> v1 = vh1.getServerName();
+	const std::vector<std::string> v2 = vh2.getServerName();
 
 	for (size_t i = 0; i < v1.size(); ++i)
 	{
@@ -52,12 +60,22 @@ bool duplicatesInServerName(VirtualHost vh1, VirtualHost vh2)
 	return false;
 }
 
+/*
+** Return true, if two VirtualHosts have the same listen directive.
+** @param vh1 First VH.
+** @param vh2 Second VH.
+** @ret bool Do the VH have the same listen.
+*/
 bool virtualHostsHaveSameListen(VirtualHost vh1, VirtualHost vh2)
 {
 	return (vh1.getListenIp() == vh2.getListenIp() &&\
 			vh1.getListenHost() == vh2.getListenHost());
 }
 
+/*
+** Check if the Config object is completely formed, and raise necessary
+** exceptions.
+*/
 void Config::check()
 {
 	for (size_t i = 0; i < virtualHostVector.size() - 1; i++)
@@ -78,65 +96,24 @@ void Config::check()
 
 }
 
+/*
+** Handle a line that belongs to Config.
+*/
 void Config::handleLine(std::string lineString)
 {
-	// std::cout << "Config handled: " << lineString << std::endl;
-
 	if (lineString.find("server") != std::string::npos)
 	{
-		// std::cout << "Found server" << std::endl;
-		// VirtualHost sBlock(this->getConfFile());
 		VirtualHost sBlock(*this);
-
-		// sBlock.inheritParams(this->clientMaxBodySize, this->autoindex,
-			// this->root, this->index);
 		sBlock.handle();
 
 		virtualHostVector.push_back(sBlock);
 	}
-	// else if (isPresent(lineString, "client_max_body_size"))
-	// {
-	// 	this->clientMaxBodySize = parseClientMaxBodySize(lineString);
-	// }
-	// else if (isPresent(lineString, "autoindex"))
-	// {
-	// 	this->autoindex = parseBoolDirective(lineString, "autoindex");
-	// }
-	// else if (isPresent(lineString, "index"))
-	// {
-	// 	this->index = ft_split(getStringDirective(lineString, "index"), ' ');
-	// }
-	// else if (isPresent(lineString, "root"))
-	// {
-	// 	this->root = getStringDirective(lineString, "root");
-	// }
 }
 
+/*
+** Getter for VirtualHost.
+*/
 std::vector<VirtualHost> Config::getVirtualHostVector(void) const
 {
 	return this->virtualHostVector;
 }
-
-// int Config::getClientMaxBodySize(void) const
-// {
-// 	return this->clientMaxBodySize;
-// }
-
-// bool Config::getAutoindex(void) const
-// {
-// 	return this->autoindex;
-// }
-
-// std::vector<std::string> Config::getIndex(void) const
-// {
-// 	return this->index;
-// }
-
-// std::string Config::getRoot(void) const
-// {
-// 	return this->root;
-// }
-
-
-
-

--- a/src/config/ConfigFile.class.cpp
+++ b/src/config/ConfigFile.class.cpp
@@ -12,10 +12,17 @@
 
 # include "ConfigFile.class.hpp"
 
+/*
+** Default constructor for ConfigFile.
+*/
 ConfigFile::ConfigFile() : _fd(-1)
 {
 }
 
+/*
+** Open the file of the config.
+** @param filename The name of the file.
+*/
 void ConfigFile::openFile(std::string filename)
 {
 	this->_fd = open(filename.c_str(), O_RDONLY);
@@ -23,6 +30,10 @@ void ConfigFile::openFile(std::string filename)
 		throw Exception("Couldn't open file");
 }
 
+/*
+** Constructor for ConfigFile that opens a file automatically.
+** @param filename The name of the file.
+*/
 ConfigFile::ConfigFile(std::string filename) :
 	_lastLineRead(false), _lastLineSent(false)
 {
@@ -31,6 +42,10 @@ ConfigFile::ConfigFile(std::string filename) :
 		throw Exception("Couldn't open file");
 }
 
+/*
+** Pass through select() before reading the config file.
+** @param fd The file description that you need to open.
+*/
 void pass_through_select(int fd)
 {
 	fd_set rfds;
@@ -56,6 +71,13 @@ void pass_through_select(int fd)
 		throw Exception("Timeout while trying to read from config file.");
 }
 
+/*
+** Read the next line of the config file.
+** Return 0 if the file has ended, so you can use this function in a while loop:
+**	while (c.getNext())
+**		...
+** @ret int Status code.
+*/
 int ConfigFile::getNext()
 {
 	if (this->_fd < 0)
@@ -83,6 +105,10 @@ int ConfigFile::getNext()
 	return this->_ret;
 }
 
+/*
+** Return the last read line in a string.
+** @ret string The last line.
+*/
 std::string ConfigFile::getLineString(void) const
 {
 	if (this->_fd < 0)
@@ -90,6 +116,11 @@ std::string ConfigFile::getLineString(void) const
 	return this->_lineString;
 }
 
+/*
+** Read the file to the end to prevent future calls to get_next_line from
+** bringing up garbage. Use if you raise an exception and plan on reading
+** other files.
+*/
 void ConfigFile::rewind(void)
 {
 	while (this->getNext())

--- a/src/config/ConfigReader.class.cpp
+++ b/src/config/ConfigReader.class.cpp
@@ -12,67 +12,26 @@
 
 #include "ConfigReader.class.hpp"
 
-void throwexp2(std::string msg)
-{
-	std::cout << "Exception: " << msg << std::endl;
-	throw Exception(msg);
-}
-
 /*
 ** Parse the file, reading server blocks into virtualHost objects in
 ** virtualHostVector member.
 */
 void ConfigReader::parse()
 {
-	// std::cout << "Parse: " << lineString << std::endl;
-
-
-	// configBlock = new Config(confFile);
-	// _config = Config(confFile)
-	// configBlock->handle();
-	// if (lineString.find("server") != std::string::npos)
-	// {
-	// 	ServerBlock sb(this->confFile);
-	// 	sb.handle();
-
-	// 	serverBlockVector.push_back(sb);
-	// 	// ABlock(this->confFile);
-
 	_config.handle();
-	configBlock = &_config;
-
-
 }
 
 ConfigReader::ConfigReader(std::string filename) :
 	confFile(filename), _config(confFile)
 {
-	// lastLineParsed = "";
-	// fd = open(filename.c_str(), O_RDONLY);
-	// if (fd < 0)
-	// 	throwexp2("Couldn't open file");
-
-	// while ((ret = fd_get_next_line(fd, &line)))
-	// {
-	// 	// std::cout << "Line read: " << line << std::endl;
-	// 	// assignLineString();
-	// 	this->lineString.assign(line);
-	// 	parse(this->lineString);
-	// }
-	// this->confFile = ConfigFile(filename);
 	while (confFile.getNext())
 	{
 		confFile.getLineString();
 		parse();
 	}
-	//check
+
+	// Check the resulting config.
 	_config.check();
-
-}
-
-Config *ConfigReader::createConfig()
-{
-	return configBlock;
 }
 
 Config ConfigReader::getConfig(void) const

--- a/src/config/Exception.class.cpp
+++ b/src/config/Exception.class.cpp
@@ -12,20 +12,32 @@
 
 #include "Exception.class.hpp"
 
+/*
+** Constructor for Exception.
+*/
 Exception::Exception(std::string _message) :
 	message(_message)
 {
 }
 
+/*
+** Copy constructor for Exception.
+*/
 Exception::Exception(const Exception &copy) :
 	message(copy.message)
 {
 }
 
+/*
+** Destructor for Exception.
+*/
 Exception::~Exception()
 {
 }
 
+/*
+** Assignment ioperator overload for Exception.
+*/
 Exception &Exception::operator= (const Exception &operand)
 {
 	if (this != &operand)
@@ -35,6 +47,9 @@ Exception &Exception::operator= (const Exception &operand)
 	return (*this);
 }
 
+/*
+** What() function for reading an exception message.
+*/
 const char* Exception::what() const throw()
 {
 	return this->message.c_str();

--- a/src/config/LimitExcept.class.cpp
+++ b/src/config/LimitExcept.class.cpp
@@ -12,10 +12,19 @@
 
 #include "LimitExcept.class.hpp"
 
+/*
+** Constructor for LimitExcept.
+*/
 LimitExcept::LimitExcept(ConfigFile &confFile) : ABlock(confFile), _empty(true)
 {
 }
 
+/*
+** Parse the methods string in the limit_except directive.
+** ex: limit_except GET POST {} will return {"GET", "POST"}
+** @param line The first line of said directive.
+** @ret vector<string> The parsed methods.
+*/
 std::vector<std::string> LimitExcept::parseMethods(std::string line)
 {
 	size_t loc_position = line.find("limit_except");
@@ -27,10 +36,11 @@ std::vector<std::string> LimitExcept::parseMethods(std::string line)
 	return ft_split(pattern, ' ');
 }
 
+/*
+** Handle a line belonging to the LimitExcept block.
+*/
 void LimitExcept::handleLine(std::string lineString)
 {
-	// std::cout << "LimitExcept handled: " << lineString << std::endl;
-
 	std::vector<std::string> appendix;
 
 	if (isPresent(lineString, "limit_except"))
@@ -52,21 +62,35 @@ void LimitExcept::handleLine(std::string lineString)
 	}
 }
 
+/*
+** Getter for _allow.
+*/
 std::vector<std::string> LimitExcept::getAllow(void) const
 {
 	return _allow;
 }
 
+/*
+** Getter for _deny.
+*/
 std::vector<std::string> LimitExcept::getDeny(void) const
 {
 	return _deny;
 }
 
+/*
+** Getter for _methods.
+*/
 std::vector<std::string> LimitExcept::getMethods(void) const
 {
 	return _methods;
 }
 
+/*
+** Return false if limitExcept wasn't specified in the parent block, and 
+** true if this block exists in the parent block.
+** @ret bool ditto.
+*/
 bool LimitExcept::isEmpty(void) const
 {
 	return _empty;

--- a/src/config/Location.class.cpp
+++ b/src/config/Location.class.cpp
@@ -12,6 +12,9 @@
 
 #include "Location.class.hpp"
 
+/*
+** Constructor for Location
+*/
 Location::Location(ConfigFile &confFile) :
 	ABlock(confFile),
 	limitExcept(confFile),
@@ -22,6 +25,9 @@ Location::Location(ConfigFile &confFile) :
 {
 }
 
+/*
+** Constructor for Location that inherits the parent block directives.
+*/
 Location::Location(ABlock &ab) :
 	ABlock(ab),
 	limitExcept(ab.getConfFile()),
@@ -57,15 +63,9 @@ std::string Location::parsePattern(std::string line)
 	return pattern;
 }
 
-// void Location::inheritParams(int _clientMaxBodySize, bool _autoindex,
-// 		std::string root, std::vector<std::string> _index, std::string _uploadStore)
-// {
-// 	this->clientMaxBodySize = _clientMaxBodySize;
-// 	this->autoindex = _autoindex;
-// 	this->index = _index;
-// 	this->uploadStore = _uploadStore;
-// }
-
+/*
+** Check if the Location block is well formed.
+*/
 void Location::check()
 {
 	if (rootSet == true && fcgiSet == true)
@@ -81,26 +81,18 @@ void Location::check()
 		throw Exception("location has to specify either root, fastcgi_pass or upload.");
 }
 
-// void Location::inheritParams(ABlock *parent)
-// {
-// 	this->clientMaxBodySize = parent->getClientMaxBodySize;
-// }
-
+/*
+** Handle a line that belongs to the location block.
+** @param lineString The line that belongs to the location block.
+*/
 void Location::handleLine(std::string lineString)
 {
-	// std::cout << "Location handled: " << lineString << std::endl;
-
 	if (lineString.find("limit_except") != std::string::npos)
 	{
-		// LimitExcept lExcept(this->getConfFile());
 		limitExcept.handle();
-
-		// limitExceptVector.push_back(lExcept);
 	}
-
 	if (isPresent(lineString, "root"))
 	{
-		// this->root = getStringDirective(lineString, "root");
 		this->rootSet = true;
 	}
 	if (isPresent(lineString, "location"))
@@ -123,66 +115,73 @@ void Location::handleLine(std::string lineString)
 	}
 }
 
+/*
+** Getter for pattern.
+*/
 std::string Location::getPattern(void) const
 {
 	return this->pattern;
 }
 
-// std::string Location::getRoot(void) const
-// {
-// 	return this->root;
-// }
-
-// int Location::getClientMaxBodySize(void) const 
-// {
-// 	return this->clientMaxBodySize;
-// }
-
-// bool Location::getAutoindex(void) const
-// {
-// 	return this->autoindex;
-// }
-
-// std::vector<std::string> Location::getIndex(void) const
-// {
-// 	return this->index;
-// }
-
+/*
+** Getter for limitExcept.
+*/
 LimitExcept Location::getLimitExcept(void) const
 {
 	return this->limitExcept;
 }
 
+/*
+** Getter for fcgiPass.
+*/
 std::string Location::getFcgiPass(void) const
 {
 	return this->fcgiPass;
 }
 
+/*
+** Getter for fcgiParams.
+*/
 std::map<std::string, std::string> Location::getFcgiParams(void) const
 {
 	return this->fcgiParams;
 }
 
+/*
+** Getter for uploadStore.
+*/
 std::string Location::getUploadStore(void) const
 {
 	return this->uploadStore;
 }
 
+/*
+** Getter for rootSet.
+*/
 bool Location::getRootSet(void) const
 {
 	return this->rootSet;
 }
 
+/*
+** Getter for fcgiSet.
+*/
 bool Location::getFcgiSet(void) const
 {
 	return this->fcgiSet;
 }
 
+/*
+** Getter for uploadStoreSet.
+*/
 bool Location::getUploadStoreSet(void) const
 {
 	return this->uploadStoreSet;
 }
 
+/*
+** Setter for uploadStore.
+*/
 void Location::setUploadStore(std::string _uploadStore)
 {
 	this->uploadStore = _uploadStore;

--- a/src/config/VirtualHost.class.cpp
+++ b/src/config/VirtualHost.class.cpp
@@ -12,90 +12,117 @@
 
 #include "VirtualHost.class.hpp"
 
+/*
+** Constructor for VirtualHost.
+*/
 VirtualHost::VirtualHost(ConfigFile &confFile) : 
 	ABlock(confFile),
-	listenIp(80),
-	listenHost("*"),
-	serverName(1, "")
+	_listenPort(80),
+	_listenHost("*"),
+	_serverName(1, "")
 {
 }
 
+/*
+** Constructor for VirtualHost that inherits the directive values from whatever
+** block is passed as a parameter.
+*/
 VirtualHost::VirtualHost(ABlock &ab) :
 	ABlock(ab),
-	listenIp(80),
-	listenHost("*"),
-	serverName(1, "")
+	_listenPort(80),
+	_listenHost("*"),
+	_serverName(1, "")
 {
 }
 
+/*
+** Handle a line that belongs to the block.
+*/
 void VirtualHost::handleLine(std::string lineString)
 {
-	// std::cout << "VirtualHost handled: " << lineString << std::endl;
 	if (lineString.find("location") != std::string::npos)
 	{
 		Location locBlock(*this);
 
-		locBlock.setUploadStore(this->uploadStore);
-
-		// locBlock.inheritParams(this->clientMaxBodySize, this->autoindex,
-			// this->root, this->index, this->uploadStore);
-
+		locBlock.setUploadStore(this->_uploadStore);
 		locBlock.handle();
 
-		locations.push_back(locBlock);
+		_locations.push_back(locBlock);
 	}
 
 	if (isPresent(lineString, "listen"))
 	{
-		parseListen(lineString, this->listenHost, this->listenIp);
+		parseListen(lineString, this->_listenHost, this->_listenPort);
 	}
 	else if (isPresent(lineString, "server_name"))
 	{
-		this->serverName = ft_split(getStringDirective(lineString,
+		this->_serverName = ft_split(getStringDirective(lineString,
 										"server_name"), ' ');
 	}
 	else if (isPresent(lineString, "upload_store"))
 	{
-		this->uploadStore = getStringDirective(lineString, "upload_store");
+		this->_uploadStore = getStringDirective(lineString, "upload_store");
 	}
-	// else if (isPresent(lineString, "root"))
-	// {
-	// 	this->root = getStringDirective(lineString, "root");
-	// }
 }
 
+/*
+** Legacy Getter for _listenPort.
+*/
 int VirtualHost::getListenIp(void) const
 {
-	return this->listenIp;
+	return this->_listenPort;
 }
 
+/*
+** Getter for _listenPort.
+*/
+int VirtualHost::getListenPort(void) const
+{
+	return this->_listenPort;
+}
+
+/*
+** Getter for _listenHost.
+*/
 std::string VirtualHost::getListenHost(void) const
 {
-	return this->listenHost;
+	return this->_listenHost;
 }
 
+/*
+** Getter for _serverName.
+*/
 std::vector<std::string> VirtualHost::getServerName(void) const
 {
-	return this->serverName;
+	return this->_serverName;
 }
 
+/*
+** Getter for _locations.
+*/
 std::vector<Location> VirtualHost::getLocations(void) const
 {
-	return this->locations;
+	return this->_locations;
 }
 
+/*
+** Getter for uploadStore.
+*/
 std::string VirtualHost::getUploadStore(void) const
 {
-	return this->uploadStore;
+	return this->_uploadStore;
 }
 
+/*
+** Check if virtualHost is well formed.
+*/
 void VirtualHost::check(void)
 {
 	// specific checks
-	if (locations.size() == 0 && this->getRoot() == "" && this->getUploadStore() == "")
+	if (_locations.size() == 0 && this->getRoot() == "" && this->getUploadStore() == "")
 		throw Exception("VirtualHost has to either have a location, or specify root or upload.");
-	for (size_t i = 0; i < locations.size(); i++)
+	for (size_t i = 0; i < _locations.size(); i++)
 	{
-		locations[i].check();
+		_locations[i].check();
 	}
 }

--- a/tests/config/config_test_main.cpp
+++ b/tests/config/config_test_main.cpp
@@ -6,7 +6,7 @@
 /*   By: ashishae <ashishae@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/12/17 17:45:02 by ashishae          #+#    #+#             */
-/*   Updated: 2021/03/03 12:35:49 by ashishae         ###   ########.fr       */
+/*   Updated: 2021/03/25 20:28:06 by ashishae         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,14 +37,6 @@ int main(void)
 	check(conf.getClientMaxBodySize() == 32);
 	check(conf.getIndex().size() == 1);
 	check(conf.getIndex()[0] == "index.html");
-
-	Config *_conf = r.createConfig();
-
-	check(_conf->getAutoindex() == true);
-	check(_conf->getClientMaxBodySize() == 32);
-	check(_conf->getIndex().size() == 1);
-	check(_conf->getIndex()[0] == "index.html");
-
 
 	std::vector<VirtualHost> virtualHostVector = conf.getVirtualHostVector();
 	check(virtualHostVector.size() == 4);


### PR DESCRIPTION
In this PR I've finished cleaning the Config files.

Also, I've renamed `VirtualHost`'s `listenIp` attribute to `listenPort`. This is because this attribute has always represented the port value.

I've left the `getListenIp` getter for convenience, but you should probably move to `getListenPort`.