### PR TITLE
Remove select(), protect write()

### DIFF
--- a/inc/CGIHandler.class.hpp
+++ b/inc/CGIHandler.class.hpp
@@ -6,7 +6,7 @@
 /*   By: ashishae <ashishae@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/30 20:21:51 by ashishae          #+#    #+#             */
-/*   Updated: 2021/04/10 18:06:45 by ablanar          ###   ########.fr       */
+/*   Updated: 2021/04/19 16:59:48 by ashishae         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -121,13 +121,11 @@ private:
 	std::vector<Header> _headers;
 
 	void readCgiResponse(int fd);
-	void writeBodyString(int fd, std::string body);
 	void countBodySize(std::string s);
 	void launch_cgi(void);
 	void execute_cgi(void);
 	void openPipes(void);
 	void prepareEnvp(void);
-	void handleCgi(void);
 	void pipeline(std::string body);
 };
 

--- a/src/cgi/CGIHandler.class.cpp
+++ b/src/cgi/CGIHandler.class.cpp
@@ -6,7 +6,7 @@
 /*   By: ashishae <ashishae@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/30 20:21:56 by ashishae          #+#    #+#             */
-/*   Updated: 2021/04/19 16:54:24 by ashishae         ###   ########.fr       */
+/*   Updated: 2021/04/19 17:02:04 by ashishae         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -178,7 +178,11 @@ void CGIHandler::pipeline(std::string body)
 	close(_pipeIn[0]);
 	// int writeTarget = _useTempFile ? _tempFileWriteFd : _pipeIn[1];
 	// std::cout << "writeTarget: " << writeTarget << std::endl;
-	writeBodyString(_pipeIn[1], body);
+
+	ssize_t write_status = write(_pipeIn[1], body.c_str(), body.size());
+	if (write_status < 0)
+		throw Exception("Error while trying to write response body to CGI");
+
 	close(_pipeIn[1]);
 	(void)_useTempFile;
 	waitpid(pid, NULL, 0);
@@ -286,38 +290,6 @@ char **create_envp(std::vector<std::string> mvars)
 }
 
 /*
-** Write the body string to a given fd.
-** @param body The request body.
-** @param fd The file descriptor where the body should be written.
-*/
-void CGIHandler::writeBodyString(int fd, std::string body)
-{
-	// extern int errno;
-	// fcntl(fd, F_SETFL, O_NONBLOCK);
-
-	// while (b != (long long) body.size())
-	// {
-	write(fd, body.c_str(), body.size());
-	// }
-	// std::cout << "Errno: " << errno << std::endl;
-	// std::cout << "Error message: " << strerror(errno) << std::endl;
-}
-
-/*
-** Launch the CGI binary in a child process, and wait for it to finish
-*/
-void CGIHandler::handleCgi(void)
-{
-
-	extern int errno;
-
-
-
-
-	// waitpid(pid, NULL, 0);
-}
-
-/*
 ** Prepare all the pipes (pipe to write in stdin, pipe to read from stdout)
 ** and launch the CGI binary.
 */
@@ -396,21 +368,11 @@ void CGIHandler::readCgiResponse(int fd)
 	fd = open("webservTmp", O_RDONLY, 0666);
 	_cgiResponse = "";
 	while ((ret = read(fd, buf, BUFFER_SIZE)))
-	// while ((ret = fd_get_next_line(fd, &respline)))
 	{
-		// std::cout << resplineString << std::endl;
-		// resplineString.assign(respline);
-		// _cgiResponse += resplineString + "\n";
 		_cgiResponse.append(buf);
 		bzero(buf, BUFFER_SIZE + 1);
 	}
-	// if (_cgiResponse.size() > 1000)
-	// 	std::cout << _cgiResponse.substr(100, 100) << std::endl;
 	close(fd);
-
-	// resplineString.assign(respline);
-	// _cgiResponse += resplineString + "\n";
-	// _cgiResponse.append(buf)
 }
 
 /*

--- a/src/cgi/CGIHandler.class.cpp
+++ b/src/cgi/CGIHandler.class.cpp
@@ -6,7 +6,7 @@
 /*   By: ashishae <ashishae@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/30 20:21:56 by ashishae          #+#    #+#             */
-/*   Updated: 2021/04/12 16:42:22 by ashishae         ###   ########.fr       */
+/*   Updated: 2021/04/19 16:54:24 by ashishae         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -178,10 +178,6 @@ void CGIHandler::pipeline(std::string body)
 	close(_pipeIn[0]);
 	// int writeTarget = _useTempFile ? _tempFileWriteFd : _pipeIn[1];
 	// std::cout << "writeTarget: " << writeTarget << std::endl;
-	fd_set wr;
-	FD_ZERO(&wr);
-	FD_SET(_pipeIn[1], &wr);
-	select(_pipeIn[1] + 1, 0, &wr, 0, 0);
 	writeBodyString(_pipeIn[1], body);
 	close(_pipeIn[1]);
 	(void)_useTempFile;
@@ -386,36 +382,6 @@ void CGIHandler::execute_cgi()
 }
 
 /*
-** As we're doing a read, we have to check if the output fd is ready for
-** reading through select().
-** @param fd The file descriptor where we will be reading the response from.
-*/
-void cgi_response_select(int fd)
-{
-	fd_set rfds;
-
-	FD_ZERO(&rfds);
-
-	FD_SET(fd, &rfds);
-
-	struct timeval tv;
-
-	/* Wait up to five seconds. */
-
-	tv.tv_sec = 5;
-	tv.tv_usec = 0;
-
-	int retval = select(fd + 1, &rfds, NULL, NULL, &tv);
-
-	if (retval == -1)
-		throw Exception("Error while trying to select() CGI response.");
-	else if (retval)
-		return ;
-	else
-		throw Exception("Timeout while trying to read CGI response.");
-}
-
-/*
 ** Read the CGI's response from the piped standard output.
 ** @param fd The file descriptor where the CGI's stdout is piped to.
 */
@@ -427,13 +393,11 @@ void CGIHandler::readCgiResponse(int fd)
 	char buf[BUFFER_SIZE + 1];
 
 	bzero(buf, BUFFER_SIZE + 1);
-	// cgi_response_select(fd);
 	fd = open("webservTmp", O_RDONLY, 0666);
 	_cgiResponse = "";
 	while ((ret = read(fd, buf, BUFFER_SIZE)))
 	// while ((ret = fd_get_next_line(fd, &respline)))
 	{
-		// cgi_response_select(fd);
 		// std::cout << resplineString << std::endl;
 		// resplineString.assign(respline);
 		// _cgiResponse += resplineString + "\n";

--- a/src/config/ConfigFile.class.cpp
+++ b/src/config/ConfigFile.class.cpp
@@ -6,7 +6,7 @@
 /*   By: ashishae <ashishae@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/02/11 12:10:39 by ashishae          #+#    #+#             */
-/*   Updated: 2021/02/11 12:10:43 by ashishae         ###   ########.fr       */
+/*   Updated: 2021/04/19 16:56:38 by ashishae         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,35 +43,6 @@ ConfigFile::ConfigFile(std::string filename) :
 }
 
 /*
-** Pass through select() before reading the config file.
-** @param fd The file description that you need to open.
-*/
-void pass_through_select(int fd)
-{
-	fd_set rfds;
-
-	FD_ZERO(&rfds);
-
-	FD_SET(fd, &rfds);
-
-	struct timeval tv;
-
-	/* Wait up to five seconds. */
-
-	tv.tv_sec = 5;
-	tv.tv_usec = 0;
-
-	int retval = select(fd + 1, &rfds, NULL, NULL, &tv);
-
-	if (retval == -1)
-		throw Exception("Error while trying to select().");
-	else if (retval)
-		return ;
-	else
-		throw Exception("Timeout while trying to read from config file.");
-}
-
-/*
 ** Read the next line of the config file.
 ** Return 0 if the file has ended, so you can use this function in a while loop:
 **	while (c.getNext())
@@ -91,8 +62,6 @@ int ConfigFile::getNext()
 		_lastLineSent = true;
 		return 0;
 	}
-
-	pass_through_select(this->_fd);
 
 	this->_ret = fd_get_next_line(this->_fd, &(this->_line));
 	this->_lineString.assign(this->_line);


### PR DESCRIPTION
This PR removes `select()` from `CGIHandler` as well as `Config`.
Also, `CGIHandler` now will throw an `Exception` if `write()` didn't return a positive value while writing body to the CGI Binary.